### PR TITLE
Update to import private module at github.com/dsrvlabs/vatz-proto

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -10,7 +10,7 @@ plugins_infos:
   default_execute_interval: 30
   default_plugin_name: "vatz-plugin"
   plugins:
-    - plugin_name: "vatz-plugin-near-node-check"
+    - plugin_name: "vatz-plugin-node-check"
       plugin_address: "localhost"
       plugin_port: 9091
       executable_methods:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dsrvlabs/vatz
 go 1.18
 
 require (
-	github.com/xellos00/dk-yuba-proto v0.0.0-20220415063750-f5c5fc059867
+	github.com/dsrvlabs/vatz-proto v0.0.0-20220420191920-c7decada518f
 	google.golang.org/grpc v1.45.0
 	google.golang.org/protobuf v1.28.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dsrvlabs/vatz-proto v0.0.0-20220420191920-c7decada518f h1:R/r14OSViw4llFU9ltWb3kwK88P/oqvLi3g6vVo67C8=
+github.com/dsrvlabs/vatz-proto v0.0.0-20220420191920-c7decada518f/go.mod h1:EBWnaJQaG6zzmvfZGZnkHN+BYfrNs4AEsUlqj5Hcch8=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/main.go
+++ b/main.go
@@ -11,15 +11,14 @@ import (
 
 	notification "github.com/dsrvlabs/vatz/manager/notification"
 
-	"github.com/dsrvlabs/vatz/manager/executor"
-
 	config "github.com/dsrvlabs/vatz/manager/config"
+	executor "github.com/dsrvlabs/vatz/manager/executor"
 	health "github.com/dsrvlabs/vatz/manager/healthcheck"
 
+	managerpb "github.com/dsrvlabs/vatz-proto/manager/v1"
+	pluginpb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	"github.com/dsrvlabs/vatz/manager/api"
 	"github.com/dsrvlabs/vatz/manager/model"
-	managerpb "github.com/xellos00/dk-yuba-proto/dist/proto/vatz/manager/v1"
-	pluginpb "github.com/xellos00/dk-yuba-proto/dist/proto/vatz/plugin/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 )

--- a/manager/api/api.go
+++ b/manager/api/api.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"context"
-	managerpb "github.com/xellos00/dk-yuba-proto/dist/proto/vatz/manager/v1"
+	managerpb "github.com/dsrvlabs/vatz-proto/manager/v1"
 )
 
 var (

--- a/manager/config/config.go
+++ b/manager/config/config.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strconv"
 
+	pluginpb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	model "github.com/dsrvlabs/vatz/manager/model"
-	pluginpb "github.com/xellos00/dk-yuba-proto/dist/proto/vatz/plugin/v1"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v2"
 )

--- a/manager/config/config_manager.go
+++ b/manager/config/config_manager.go
@@ -1,8 +1,8 @@
 package config
 
 import (
+	pluginpb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	model "github.com/dsrvlabs/vatz/manager/model"
-	pluginpb "github.com/xellos00/dk-yuba-proto/dist/proto/vatz/plugin/v1"
 )
 
 var (

--- a/manager/executor/executor.go
+++ b/manager/executor/executor.go
@@ -3,8 +3,8 @@ package executor
 import (
 	"context"
 
+	pluginpb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	message "github.com/dsrvlabs/vatz/manager/model"
-	pluginpb "github.com/xellos00/dk-yuba-proto/dist/proto/vatz/plugin/v1"
 )
 
 type executor struct {

--- a/manager/executor/executor_manager.go
+++ b/manager/executor/executor_manager.go
@@ -3,8 +3,8 @@ package executor
 import (
 	"log"
 
+	pluginpb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	"github.com/dsrvlabs/vatz/manager/notification"
-	pluginpb "github.com/xellos00/dk-yuba-proto/dist/proto/vatz/plugin/v1"
 	"google.golang.org/protobuf/types/known/structpb"
 	//"vatz/manager/config"
 )

--- a/manager/healthcheck/healthcheck.go
+++ b/manager/healthcheck/healthcheck.go
@@ -3,10 +3,10 @@ package healthcheck
 import (
 	"context"
 
+	pluginpb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	"github.com/dsrvlabs/vatz/manager/config"
 	msg "github.com/dsrvlabs/vatz/manager/model"
 	"github.com/dsrvlabs/vatz/manager/notification"
-	pluginpb "github.com/xellos00/dk-yuba-proto/dist/proto/vatz/plugin/v1"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
 )
 

--- a/manager/healthcheck/healthcheck_manager.go
+++ b/manager/healthcheck/healthcheck_manager.go
@@ -1,7 +1,7 @@
 package healthcheck
 
 import (
-	pluginpb "github.com/xellos00/dk-yuba-proto/dist/proto/vatz/plugin/v1"
+	pluginpb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 )
 
 var (

--- a/manager/notification/notification.go
+++ b/manager/notification/notification.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"net/http"
 
+	pluginpb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	message "github.com/dsrvlabs/vatz/manager/model"
-	pluginpb "github.com/xellos00/dk-yuba-proto/dist/proto/vatz/plugin/v1"
 )
 
 type notification struct {

--- a/manager/notification/notification_manager.go
+++ b/manager/notification/notification_manager.go
@@ -3,7 +3,7 @@ package notification
 import (
 	model "github.com/dsrvlabs/vatz/manager/model"
 
-	pluginpb "github.com/xellos00/dk-yuba-proto/dist/proto/vatz/plugin/v1"
+	pluginpb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 
 	config "github.com/dsrvlabs/vatz/manager/config"
 )


### PR DESCRIPTION
close #73 

> Update vatz source code to replace importing public grpc proto to private dsrvlabs/vatz-proto