### PR TITLE
Support grpc health check (#166)

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ import (
 	"github.com/dsrvlabs/vatz/manager/api"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
+	grpchealth "google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 const (
@@ -79,6 +81,7 @@ func initiateServer(ch <-chan os.Signal) error {
 
 	log.Println("Node Manager Started")
 
+	InitHealthServer(s)
 	if err := s.Serve(listener); err != nil {
 		log.Panic(err)
 	}
@@ -155,4 +158,10 @@ func multiPluginExecutor(plugin config.Plugin,
 			return
 		}
 	}
+}
+
+func InitHealthServer(s *grpc.Server) {
+	healthserver := grpchealth.NewServer()
+	healthserver.SetServingStatus("vatz-health-status", healthpb.HealthCheckResponse_SERVING)
+	healthpb.RegisterHealthServer(s, healthserver)
 }


### PR DESCRIPTION

### 1. Type of change

Please delete options that are not relevant.

- [X] New feature
- [ ] Enhancement
- [ ] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

**Related:** #166 , https://github.com/dsrvlabs/vatz-plugin-solana/pull/17

**Summary**
- import grpc/health package
- set serving status for response from health check request
- vatz can support grpc health check protocol with this change.
- Related PR (https://github.com/dsrvlabs/vatz-plugin-solana/pull/17) is plugin type health checker using grpc health check protocol.


---

### 3. Comments
> Please, leave a comments if there's further action that requires. 

Please refer to the below comment about health checker plugin.
https://github.com/dsrvlabs/vatz-plugin-solana/pull/17#issue-1309642494