### PR TITLE
Remove panic and kill vatz process only if vatz fails to find config yaml file. 

### DIFF
--- a/manager/config/config.go
+++ b/manager/config/config.go
@@ -136,7 +136,7 @@ func InitConfig(configFile string) *Config {
 		if err != nil {
 			if strings.Contains(err.Error(), "no such file or directory") {
 				log.Error().Str("module", "config").Msgf("loadConfig Error: %s", err)
-				log.Error().Str("module", "config").Msg("Please, initialize VATZ with command `.vatz init` to create config file `default.yaml` first or set appropriate path for config file `default.yaml`.")
+				log.Error().Str("module", "config").Msg("Please, initialize VATZ with command `./vatz init` to create config file `default.yaml` first or set appropriate path for config file `default.yaml`.")
 				os.Exit(1)
 			}
 			panic(err)


### PR DESCRIPTION
### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Enhancement
- [x] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

**Related:** # (issue)
close #259 

**Summary**

No panic and vatz dies if vatz fails to find default.yaml or get wrong yaml path. 
as below
```
 ./vatz start
2022-10-09T02:52:18-05:00 INF start module=main
2022-10-09T02:52:18-05:00 INF load config default.yaml module=main
2022-10-09T02:52:18-05:00 INF logfile  module=main
2022-10-09T02:52:18-05:00 ERR loadConfig Error: open default.yaml: no such file or directory module=config
2022-10-09T02:52:18-05:00 ERR Please, initialize VATZ with command `.vatz init` to create config file `default.yaml` first or set appropriate path for config file `default.yaml`. module=config
 ✘ dongyookang DK 💡   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-259 ±
```
```
 ./vatz start --config default2.yaml
2022-10-09T02:54:54-05:00 INF start module=main
2022-10-09T02:54:54-05:00 INF load config default2.yaml module=main
2022-10-09T02:54:54-05:00 INF logfile  module=main
2022-10-09T02:54:54-05:00 ERR loadConfig Error: open default2.yaml: no such file or directory module=config
2022-10-09T02:54:54-05:00 ERR Please, initialize VATZ with command `.vatz init` to create config file `default.yaml` first or set appropriate path for config file `default.yaml`. module=config
 ✘ dongyookang DK 💡   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-259
 


```

---