### PR TITLE
fix bad message format when it starts to run

### DIFF
--- a/manager/config/config.go
+++ b/manager/config/config.go
@@ -164,13 +164,10 @@ func InitConfig(configFile string) (*Config, error) {
 	wg.Add(1)
 
 	configOnce.Do(func() {
+		log.Info().Str("module", "config").Msgf("Load Config %s", configFile)
+
 		defer wg.Done()
-
-		log.Error().Str("module", "config").Msgf("Load Config %s", configFile)
-
-		var (
-			configData []byte
-		)
+		var configData []byte
 
 		p := parser{}
 		configData, configError = p.loadConfigFile(configFile)


### PR DESCRIPTION
### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Enhancement
- [x] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

Remove Error message on logs that should not be on logs

**Related:** # (issue)

close #282 

**Summary**

Error message shouldn't be on the log when it starts run properly. 

---

### 3. Prep
> Please, leave a comments if there's further action that requires. 

<img width="664" alt="image" src="https://user-images.githubusercontent.com/6308023/196826977-753288d7-6d0e-418f-b71b-8f099ef44e55.png">

<img width="829" alt="image" src="https://user-images.githubusercontent.com/6308023/196827127-64ba3630-e9e9-48d0-8ae4-3b13ecceff57.png">

```
 dongyookang DK 🐵   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-282
 make clean
fatal: No names found, cannot describe anything.
go clean
 dongyookang DK 🐵   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-282
 make build
fatal: No names found, cannot describe anything.
go build -ldflags="-X 'main.Version=ISSUE-282' -X 'main.Commit=9a324a0'" -v
 dongyookang DK 🐵   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-282
 ./vatz init                        
2022-10-19T19:04:31-05:00 INF init module=main
2022-10-19T19:04:31-05:00 INF create file default.yaml module=main
 dongyookang DK 🐵   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-282
 ./vatz start                       
2022-10-19T19:04:44-05:00 INF start module=main
2022-10-19T19:04:44-05:00 INF load config default.yaml module=main
2022-10-19T19:04:44-05:00 INF logfile  module=main
2022-10-19T19:04:44-05:00 INF Load Config default.yaml module=config
2022-10-19T19:04:44-05:00 INF Initialize Servers: VATZ Manager module=main
2022-10-19T19:04:44-05:00 INF VATZ Listening Port: :9090 module=main
2022-10-19T19:04:44-05:00 INF VATZ Manager Started module=main
2022-10-19T19:04:44-05:00 INF start rpc server module=rpc
2022-10-19T19:04:44-05:00 INF start gRPC gateway server 127.0.0.1:19091 module=rpc
2022-10-19T19:04:44-05:00 INF start gRPC server 127.0.0.1:19090 module=rpc
^C
 ✘ dongyookang DK 🐵   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-282
 make coverage
fatal: No names found, cannot describe anything.
echo "Test Coverage script will be here"
Test Coverage script will be here
ok      github.com/dsrvlabs/vatz        0.683s  coverage: 10.7% of statements
ok      github.com/dsrvlabs/vatz/manager/api    0.267s  coverage: 0.0% of statements [no tests to run]
ok      github.com/dsrvlabs/vatz/manager/config 0.205s  coverage: 92.0% of statements
ok      github.com/dsrvlabs/vatz/manager/dispatcher     0.356s  coverage: 8.9% of statements
ok      github.com/dsrvlabs/vatz/manager/executor       0.594s  coverage: 68.2% of statements
ok      github.com/dsrvlabs/vatz/manager/healthcheck    0.470s  coverage: 45.0% of statements
?       github.com/dsrvlabs/vatz/manager/types  [no test files]
?       github.com/dsrvlabs/vatz/mocks  [no test files]
ok      github.com/dsrvlabs/vatz/rpc    1.803s  coverage: 67.2% of statements
 dongyookang DK 🐵   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-282
 

```