### PR TITLE
Add Options in ReqMsg to use unique name in key

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -18,8 +18,8 @@ var (
 	healthChecker          = health.GetHealthChecker()
 	executor               = ex.NewExecutor()
 	dispatchers            []dp.Dispatcher
-	defaultVerifyInterval  = 15
-	defaultExecuteInterval = 30
+	defaultVerifyInterval  = 15 //nolint:golint,unused
+	defaultExecuteInterval = 30 //nolint:golint,unused
 
 	configFile string
 	logfile    string

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	grpchealth "google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
@@ -128,7 +129,7 @@ func getClients(plugins []config.Plugin) []pluginpb.PluginClient {
 
 	if len(plugins) > 0 {
 		for _, plugin := range plugins {
-			conn, err := grpc.Dial(fmt.Sprintf("%s:%d", plugin.Address, plugin.Port), grpc.WithInsecure())
+			conn, err := grpc.Dial(fmt.Sprintf("%s:%d", plugin.Address, plugin.Port), grpc.WithTransportCredentials(insecure.NewCredentials()))
 			if err != nil {
 				log.Fatal().Str("module", "main").Msgf("gRPC Dial Error(%s): %s", plugin.Name, err)
 			}
@@ -137,7 +138,7 @@ func getClients(plugins []config.Plugin) []pluginpb.PluginClient {
 	} else {
 		// TODO: Is this really neccessary???
 		defaultConnectedTarget := "localhost:9091"
-		conn, err := grpc.Dial(defaultConnectedTarget, grpc.WithInsecure())
+		conn, err := grpc.Dial(defaultConnectedTarget, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			log.Fatal().Str("module", "main").Msgf("gRPC Dial Error: %s", err)
 		}

--- a/manager/config/config.go
+++ b/manager/config/config.go
@@ -103,7 +103,7 @@ func (p *parser) loadConfigFile(path string) ([]byte, error) {
 			return nil, fmt.Errorf("invalid response status %d", resp.StatusCode)
 		}
 
-		rawYAML, err = io.ReadAll(resp.Body)
+		rawYAML, _ = io.ReadAll(resp.Body)
 	} else {
 		rawYAML, err = ioutil.ReadFile(path)
 	}

--- a/manager/config/config.go
+++ b/manager/config/config.go
@@ -85,7 +85,7 @@ type Plugin struct {
 }
 
 type parser struct {
-	rawConfig map[string]interface{}
+	rawConfig map[string]interface{} //nolint:golint,unused
 }
 
 func (p *parser) loadConfigFile(path string) ([]byte, error) {
@@ -95,7 +95,7 @@ func (p *parser) loadConfigFile(path string) ([]byte, error) {
 	)
 
 	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
-		resp, err := http.Get(path)
+		resp, err := http.Get(path) //nolint:gosec
 		if err != nil {
 			return nil, err
 		}

--- a/manager/dispatcher/discord.go
+++ b/manager/dispatcher/discord.go
@@ -119,11 +119,11 @@ func (d *discord) SendNotification(msg tp.ReqMsg) error {
 		c := &http.Client{}
 		_, err = c.Do(req)
 		if err != nil {
-			log.Error().Str("module", "dispatcher").Msgf("Channel(Discord): Send notification error: %s", err)
+			log.Error().Str("module", "dispatcher:discord").Msgf("Channel(Discord): Send notification error: %s", err)
 		}
 		// TODO: Should handle response status.
 	} else {
-		log.Error().Str("module", "dispatcher").Msg("Channel(Discord): Connection failed due to Invalid discord webhook address")
+		log.Error().Str("module", "dispatcher:discord").Msg("Channel(Discord): Connection failed due to Invalid discord webhook address")
 	}
 	return nil
 }

--- a/manager/dispatcher/discord.go
+++ b/manager/dispatcher/discord.go
@@ -117,7 +117,7 @@ func (d *discord) SendNotification(msg tp.ReqMsg) error {
 		req, _ := http.NewRequest("POST", d.secret, bytes.NewReader(message))
 		req.Header.Set("Content-Type", "application/json")
 		c := &http.Client{}
-		_, err = c.Do(req)
+		_, err = c.Do(req) //nolint:bodyclose
 		if err != nil {
 			log.Error().Str("module", "dispatcher:discord").Msgf("Channel(Discord): Send notification error: %s", err)
 		}

--- a/manager/dispatcher/discord.go
+++ b/manager/dispatcher/discord.go
@@ -13,7 +13,6 @@ import (
 
 	pb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	tp "github.com/dsrvlabs/vatz/manager/types"
-	"github.com/dsrvlabs/vatz/utils"
 	"github.com/rs/zerolog/log"
 )
 
@@ -38,7 +37,7 @@ type discord struct {
 
 func (d *discord) SetDispatcher(firstRunMsg bool, preStat tp.StateFlag, notifyInfo tp.NotifyInfo) error {
 	reqToNotify, reminderState, deliverMessage := messageHandler(firstRunMsg, preStat, notifyInfo)
-	pUnique := utils.MakeUniqueValue(notifyInfo.Plugin, notifyInfo.Address, notifyInfo.Port)
+	pUnique := deliverMessage.Option["pUnique"].(string)
 
 	if reqToNotify {
 		d.SendNotification(deliverMessage)

--- a/manager/dispatcher/discord.go
+++ b/manager/dispatcher/discord.go
@@ -40,7 +40,7 @@ func (d *discord) SetDispatcher(firstRunMsg bool, preStat tp.StateFlag, notifyIn
 	pUnique := deliverMessage.Option["pUnique"].(string)
 
 	if reqToNotify {
-		d.SendNotification(deliverMessage)
+		_ = d.SendNotification(deliverMessage)
 	}
 
 	if reminderState == tp.ON {
@@ -58,7 +58,7 @@ func (d *discord) SetDispatcher(firstRunMsg bool, preStat tp.StateFlag, notifyIn
 		}
 		for _, schedule := range d.reminderSchedule {
 			id, _ := d.reminderCron.AddFunc(schedule, func() {
-				d.SendNotification(deliverMessage)
+				_ = d.SendNotification(deliverMessage)
 			})
 			newEntries = append(newEntries, id)
 		}

--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -2,6 +2,7 @@ package dispatcher
 
 import (
 	"errors"
+	"github.com/dsrvlabs/vatz/utils"
 	"strings"
 	"sync"
 	"time"
@@ -88,6 +89,10 @@ func messageHandler(isFirst bool, preStat tp.StateFlag, info tp.NotifyInfo) (boo
 	reminderState := tp.HANG
 	isFlagStateChanged := false
 
+	pUnique := utils.MakeUniqueValue(info.Plugin, info.Address, info.Port)
+	option := make(map[string]interface{})
+	option["pUnique"] = pUnique
+
 	if preStat.State != info.State || preStat.Severity != info.Severity {
 		isFlagStateChanged = true
 	}
@@ -110,5 +115,6 @@ func messageHandler(isFirst bool, preStat tp.StateFlag, info tp.NotifyInfo) (boo
 		Msg:          info.ExecuteMsg,
 		Severity:     info.Severity,
 		ResourceType: info.Plugin,
+		Option:       option,
 	}
 }

--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -36,6 +36,7 @@ func TestMessageHandler(t *testing.T) {
 		ExecuteMsg: "ExecuteMsg",
 	}
 
+	pUnique0 := map[string]interface{}{"pUnique": "SamplePlugin0"}
 	no1, reminderSt1, deliverMessage1 := messageHandler(true, preStat, notifyInfoTPOn)
 	no2, reminderSt2, deliverMessage2 := messageHandler(false, preStat, notifyInfoTPOff)
 	no3, reminderSt3, deliverMessage3 := messageHandler(false, preStat, notifyInfoTPHang)
@@ -48,6 +49,7 @@ func TestMessageHandler(t *testing.T) {
 		Msg:          "ExecuteMsg",
 		Severity:     pb.SEVERITY_WARNING,
 		ResourceType: "SamplePlugin",
+		Option:       pUnique0,
 	}, deliverMessage1)
 
 	assert.False(t, false == no2)
@@ -58,6 +60,7 @@ func TestMessageHandler(t *testing.T) {
 		Msg:          "ExecuteMsg",
 		Severity:     pb.SEVERITY_INFO,
 		ResourceType: "SamplePlugin",
+		Option:       pUnique0,
 	}, deliverMessage2)
 
 	assert.False(t, no3)
@@ -68,5 +71,6 @@ func TestMessageHandler(t *testing.T) {
 		Msg:          "ExecuteMsg",
 		Severity:     pb.SEVERITY_CRITICAL,
 		ResourceType: "SamplePlugin",
+		Option:       pUnique0,
 	}, deliverMessage3)
 }

--- a/manager/dispatcher/pagerduty.go
+++ b/manager/dispatcher/pagerduty.go
@@ -38,7 +38,7 @@ func (p *pagerduty) SendNotification(msg tp.ReqMsg) error {
 	var (
 		pagerdutySeverity string
 		emoji             string
-		methodName        = msg.FuncName
+		methodName        = msg.Option["pUnique"].(string)
 	)
 	/*
 		Pagerduty severity Allowed values:

--- a/manager/dispatcher/pagerduty.go
+++ b/manager/dispatcher/pagerduty.go
@@ -28,7 +28,7 @@ type pagerduty struct {
 func (p *pagerduty) SetDispatcher(firstRunMsg bool, preStat tp.StateFlag, notifyInfo tp.NotifyInfo) error {
 	reqToNotify, _, deliverMessage := messageHandler(firstRunMsg, preStat, notifyInfo)
 	if reqToNotify {
-		p.SendNotification(deliverMessage)
+		_ = p.SendNotification(deliverMessage)
 	}
 	return nil
 }
@@ -78,7 +78,7 @@ Plugin Name: %s
 	if pb.STATE_SUCCESS != msg.State || pb.SEVERITY_INFO != msg.Severity {
 		resp, err := pd.ManageEventWithContext(ctx, pd.V2Event{RoutingKey: p.secret, Action: "trigger", Payload: v2EventPayload})
 		if err != nil {
-			log.Error().Str("module", "dispatcher").Msgf("Channel(Pagerduty): Connection failed due to Error: %s", err)
+			log.Error().Str("module", "dispatcher:pagerduty").Msgf("Channel(Pagerduty): Connection failed due to Error: %s", err)
 			return err
 		}
 		if resp.Status == SUCCESS {
@@ -99,7 +99,7 @@ Plugin Name: %s
 				Payload:    v2EventPayload,
 			})
 			if err != nil {
-				log.Error().Str("module", "dispatcher").Msgf("Channel(Pagerduty): Connection failed due to Error: %s", err)
+				log.Error().Str("module", "dispatcher:pagerduty").Msgf("Channel(Pagerduty): Connection failed due to Error: %s", err)
 				return err
 			}
 		}

--- a/manager/dispatcher/telegram.go
+++ b/manager/dispatcher/telegram.go
@@ -10,7 +10,6 @@ import (
 
 	pb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	tp "github.com/dsrvlabs/vatz/manager/types"
-	"github.com/dsrvlabs/vatz/utils"
 	"github.com/robfig/cron/v3"
 	"github.com/rs/zerolog/log"
 )
@@ -29,12 +28,11 @@ type telegram struct {
 
 func (t *telegram) SetDispatcher(firstRunMsg bool, preStat tp.StateFlag, notifyInfo tp.NotifyInfo) error {
 	reqToNotify, reminderState, deliverMessage := messageHandler(firstRunMsg, preStat, notifyInfo)
+	pUnique := deliverMessage.Option["pUnique"].(string)
 
 	if reqToNotify {
 		t.SendNotification(deliverMessage)
 	}
-
-	pUnique := utils.MakeUniqueValue(notifyInfo.Plugin, notifyInfo.Address, notifyInfo.Port)
 
 	if reminderState == tp.ON {
 		newEntries := []cron.EntryID{}

--- a/manager/executor/executor_test.go
+++ b/manager/executor/executor_test.go
@@ -61,11 +61,11 @@ func TestExecutorSuccess(t *testing.T) {
 		}
 
 		// Mocks.
-		mockExeInfo, err := structpb.NewStruct(map[string]interface{}{
+		mockExeInfo, err := structpb.NewStruct(map[string]interface{}{ //nolint:ineffassign
 			"execute_method": testMethodName,
 		})
 
-		mockOpts, err := structpb.NewStruct(map[string]interface{}{
+		mockOpts, err := structpb.NewStruct(map[string]interface{}{ //nolint:ineffassign
 			"plugin_name": testPluginName,
 		})
 
@@ -182,11 +182,12 @@ func TestExecutorFailure(t *testing.T) {
 		}
 
 		// Mocks.
-		mockExeInfo, err := structpb.NewStruct(map[string]interface{}{
+
+		mockExeInfo, err := structpb.NewStruct(map[string]interface{}{ //nolint:ineffassign
 			"execute_method": testMethodName,
 		})
 
-		mockOpts, err := structpb.NewStruct(map[string]interface{}{
+		mockOpts, err := structpb.NewStruct(map[string]interface{}{ //nolint:ineffassign
 			"plugin_name": testPluginName,
 		})
 
@@ -210,7 +211,7 @@ func TestExecutorFailure(t *testing.T) {
 
 		err = e.Execute(ctx, &mockClient, cfgPlugin, mockNotifs)
 
-		fmt.Println("Status", e.status)
+		fmt.Println("Status", e.status) //nolint:govet
 
 		// Asserts
 		mockClient.AssertExpectations(t)

--- a/manager/executor/general_executor.go
+++ b/manager/executor/general_executor.go
@@ -54,7 +54,7 @@ func (s *executor) Execute(ctx context.Context, gClient pluginpb.PluginClient, p
 		firstExe, preStatus := s.updateState(pUnique, resp)
 
 		for _, dp := range dispatchers {
-			dp.SetDispatcher(firstExe, preStatus, tp.NotifyInfo{
+			err = dp.SetDispatcher(firstExe, preStatus, tp.NotifyInfo{
 				Plugin:     plugin.Name,
 				Method:     method.Name,
 				Address:    plugin.Address,
@@ -63,6 +63,9 @@ func (s *executor) Execute(ctx context.Context, gClient pluginpb.PluginClient, p
 				State:      resp.GetState(),
 				ExecuteMsg: resp.GetMessage(),
 			})
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/manager/healthcheck/general_healthcheck.go
+++ b/manager/healthcheck/general_healthcheck.go
@@ -30,12 +30,16 @@ func (h *healthChecker) PluginHealthCheck(ctx context.Context, gClient pb.Plugin
 	pUnique := utils.MakeUniqueValue(plugin.Name, plugin.Address, plugin.Port)
 	verify, err := gClient.Verify(ctx, new(emptypb.Empty))
 
+	option := make(map[string]interface{})
+	option["pUnique"] = pUnique
+
 	deliverMSG := tp.ReqMsg{
 		FuncName:     "isPluginUp",
 		State:        pb.STATE_FAILURE,
 		Msg:          "Plugin is DOWN!!",
 		Severity:     pb.SEVERITY_CRITICAL,
 		ResourceType: plugin.Name,
+		Option:       option,
 	}
 
 	if _, ok := h.pluginStatus.Load(pUnique); !ok {

--- a/manager/healthcheck/general_healthcheck.go
+++ b/manager/healthcheck/general_healthcheck.go
@@ -67,7 +67,7 @@ func (h *healthChecker) PluginHealthCheck(ctx context.Context, gClient pb.Plugin
 
 	if sendMSG {
 		for _, dispatcher := range dispatchers {
-			dispatcher.SendNotification(deliverMSG)
+			_ = dispatcher.SendNotification(deliverMSG)
 		}
 	}
 
@@ -83,7 +83,7 @@ func (h *healthChecker) PluginHealthCheck(ctx context.Context, gClient pb.Plugin
 func (h *healthChecker) VATZHealthCheck(healthCheckerSchedule []string, dispatchers []dp.Dispatcher) error {
 	c := cron.New(cron.WithLocation(time.UTC))
 	for i := 0; i < len(healthCheckerSchedule); i++ {
-		c.AddFunc(healthCheckerSchedule[i], func() {
+		_, _ = c.AddFunc(healthCheckerSchedule[i], func() {
 			for _, dispatcher := range dispatchers {
 				dispatcher.SendNotification(h.healthMSG)
 			}
@@ -92,7 +92,6 @@ func (h *healthChecker) VATZHealthCheck(healthCheckerSchedule []string, dispatch
 	c.Start()
 	return nil
 }
-
 func (h *healthChecker) PluginStatus(ctx context.Context) []tp.PluginStatus {
 	status := make([]tp.PluginStatus, 0)
 

--- a/manager/healthcheck/general_healthcheck.go
+++ b/manager/healthcheck/general_healthcheck.go
@@ -85,7 +85,7 @@ func (h *healthChecker) VATZHealthCheck(healthCheckerSchedule []string, dispatch
 	for i := 0; i < len(healthCheckerSchedule); i++ {
 		_, _ = c.AddFunc(healthCheckerSchedule[i], func() {
 			for _, dispatcher := range dispatchers {
-				dispatcher.SendNotification(h.healthMSG)
+				_ = dispatcher.SendNotification(h.healthMSG)
 			}
 		})
 	}

--- a/manager/types/dispatcher.go
+++ b/manager/types/dispatcher.go
@@ -11,11 +11,12 @@ type DiscordColor int
 
 //Let's Setup this message into GRPC Type
 type ReqMsg struct {
-	FuncName     string            `json:"func_name"`
-	State        pluginpb.STATE    `json:"state"`
-	Msg          string            `json:"msg"`
-	Severity     pluginpb.SEVERITY `json:"severity"`
-	ResourceType string            `json:"resource_type"`
+	FuncName     string                 `json:"func_name"`
+	State        pluginpb.STATE         `json:"state"`
+	Msg          string                 `json:"msg"`
+	Severity     pluginpb.SEVERITY      `json:"severity"`
+	ResourceType string                 `json:"resource_type"`
+	Option       map[string]interface{} `json:"option"`
 }
 
 func (r *ReqMsg) UpdateState(stat pluginpb.STATE) {

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -105,7 +105,7 @@ func (s *rpcService) Stop() {
 	defer s.cancel()
 
 	if s.httpServer != nil {
-		s.httpServer.Shutdown(s.ctx)
+		_ = s.httpServer.Shutdown(s.ctx)
 	}
 
 	log.Info().Str("module", "rpc").Msg("stop")

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/rs/zerolog/log"
 	"io"
 	"net/http"
 	"testing"
@@ -21,7 +22,12 @@ import (
 func TestRPCs(t *testing.T) {
 	rpc := NewRPCService()
 
-	go rpc.Start("127.0.0.1", 19090, 19091)
+	go func() {
+		err := rpc.Start("127.0.0.1", 19090, 19091)
+		if err != nil {
+			log.Error().Str("module", "test_RPC").Msgf("Channel(Test): RPC start Error: %s", err)
+		}
+	}()
 
 	time.Sleep(time.Second * 1) // Wait ready
 


### PR DESCRIPTION
### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Enhancement
- [ ] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

Add Options in ReqMsg to use unique name in key

**Related:** # (issue)
close #314

**Summary**
previously, only plugin's method name has used as key to store plugins, it would be malfunctional if there's same plugin & method name in config.yaml. It's has been fixed by @gnongs but didn't fix it on pagerduty because it hadn't developed when he send PR.  

This PR fix pagerduty to use a sync.map's key with plugin + address + port so it fix use method name as key in pagerduty.go

---

### 3. Comments
> Please, leave a comments if there's further action that requires. 