### PR TITLE
Add Options in ReqMsg to use unique name in key

### DIFF
--- a/manager/dispatcher/discord.go
+++ b/manager/dispatcher/discord.go
@@ -9,11 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/robfig/cron/v3"
-
 	pb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	tp "github.com/dsrvlabs/vatz/manager/types"
-	"github.com/dsrvlabs/vatz/utils"
+	"github.com/robfig/cron/v3"
 	"github.com/rs/zerolog/log"
 )
 
@@ -38,7 +36,7 @@ type discord struct {
 
 func (d *discord) SetDispatcher(firstRunMsg bool, preStat tp.StateFlag, notifyInfo tp.NotifyInfo) error {
 	reqToNotify, reminderState, deliverMessage := messageHandler(firstRunMsg, preStat, notifyInfo)
-	pUnique := utils.MakeUniqueValue(notifyInfo.Plugin, notifyInfo.Address, notifyInfo.Port)
+	pUnique := deliverMessage.Options["pUnique"].(string)
 
 	if reqToNotify {
 		d.SendNotification(deliverMessage)

--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -2,6 +2,7 @@ package dispatcher
 
 import (
 	"errors"
+	"github.com/dsrvlabs/vatz/utils"
 	"strings"
 	"sync"
 	"time"
@@ -88,6 +89,8 @@ func messageHandler(isFirst bool, preStat tp.StateFlag, info tp.NotifyInfo) (boo
 	reminderState := tp.HANG
 	isFlagStateChanged := false
 
+	pUnique := utils.MakeUniqueValue(info.Plugin, info.Address, info.Port)
+
 	if preStat.State != info.State || preStat.Severity != info.Severity {
 		isFlagStateChanged = true
 	}
@@ -110,5 +113,6 @@ func messageHandler(isFirst bool, preStat tp.StateFlag, info tp.NotifyInfo) (boo
 		Msg:          info.ExecuteMsg,
 		Severity:     info.Severity,
 		ResourceType: info.Plugin,
+		Options:      map[string]interface{}{"pUnique": pUnique},
 	}
 }

--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -35,7 +35,7 @@ func TestMessageHandler(t *testing.T) {
 		Severity:   pb.SEVERITY_CRITICAL,
 		ExecuteMsg: "ExecuteMsg",
 	}
-
+	dummyOptions := map[string]interface{}{"pUnique": "SamplePlugin0"}
 	no1, reminderSt1, deliverMessage1 := messageHandler(true, preStat, notifyInfoTPOn)
 	no2, reminderSt2, deliverMessage2 := messageHandler(false, preStat, notifyInfoTPOff)
 	no3, reminderSt3, deliverMessage3 := messageHandler(false, preStat, notifyInfoTPHang)
@@ -48,6 +48,7 @@ func TestMessageHandler(t *testing.T) {
 		Msg:          "ExecuteMsg",
 		Severity:     pb.SEVERITY_WARNING,
 		ResourceType: "SamplePlugin",
+		Options:      dummyOptions,
 	}, deliverMessage1)
 
 	assert.False(t, false == no2)
@@ -58,6 +59,7 @@ func TestMessageHandler(t *testing.T) {
 		Msg:          "ExecuteMsg",
 		Severity:     pb.SEVERITY_INFO,
 		ResourceType: "SamplePlugin",
+		Options:      dummyOptions,
 	}, deliverMessage2)
 
 	assert.False(t, no3)
@@ -68,5 +70,6 @@ func TestMessageHandler(t *testing.T) {
 		Msg:          "ExecuteMsg",
 		Severity:     pb.SEVERITY_CRITICAL,
 		ResourceType: "SamplePlugin",
+		Options:      dummyOptions,
 	}, deliverMessage3)
 }

--- a/manager/dispatcher/pagerduty.go
+++ b/manager/dispatcher/pagerduty.go
@@ -38,7 +38,7 @@ func (p *pagerduty) SendNotification(msg tp.ReqMsg) error {
 	var (
 		pagerdutySeverity string
 		emoji             string
-		methodName        = msg.FuncName
+		methodName        = msg.Options["pUnique"].(string)
 	)
 	/*
 		Pagerduty severity Allowed values:

--- a/manager/dispatcher/telegram.go
+++ b/manager/dispatcher/telegram.go
@@ -10,7 +10,6 @@ import (
 
 	pb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	tp "github.com/dsrvlabs/vatz/manager/types"
-	"github.com/dsrvlabs/vatz/utils"
 	"github.com/robfig/cron/v3"
 	"github.com/rs/zerolog/log"
 )
@@ -29,12 +28,11 @@ type telegram struct {
 
 func (t *telegram) SetDispatcher(firstRunMsg bool, preStat tp.StateFlag, notifyInfo tp.NotifyInfo) error {
 	reqToNotify, reminderState, deliverMessage := messageHandler(firstRunMsg, preStat, notifyInfo)
+	pUnique := deliverMessage.Options["pUnique"].(string)
 
 	if reqToNotify {
 		t.SendNotification(deliverMessage)
 	}
-
-	pUnique := utils.MakeUniqueValue(notifyInfo.Plugin, notifyInfo.Address, notifyInfo.Port)
 
 	if reminderState == tp.ON {
 		newEntries := []cron.EntryID{}

--- a/manager/healthcheck/general_healthcheck.go
+++ b/manager/healthcheck/general_healthcheck.go
@@ -30,12 +30,15 @@ func (h *healthChecker) PluginHealthCheck(ctx context.Context, gClient pb.Plugin
 	pUnique := utils.MakeUniqueValue(plugin.Name, plugin.Address, plugin.Port)
 	verify, err := gClient.Verify(ctx, new(emptypb.Empty))
 
+	option := map[string]interface{}{"pUnique": pUnique}
+
 	deliverMSG := tp.ReqMsg{
 		FuncName:     "isPluginUp",
 		State:        pb.STATE_FAILURE,
 		Msg:          "Plugin is DOWN!!",
 		Severity:     pb.SEVERITY_CRITICAL,
 		ResourceType: plugin.Name,
+		Options:      option,
 	}
 
 	if _, ok := h.pluginStatus.Load(pUnique); !ok {

--- a/manager/types/dispatcher.go
+++ b/manager/types/dispatcher.go
@@ -11,11 +11,12 @@ type DiscordColor int
 
 //Let's Setup this message into GRPC Type
 type ReqMsg struct {
-	FuncName     string            `json:"func_name"`
-	State        pluginpb.STATE    `json:"state"`
-	Msg          string            `json:"msg"`
-	Severity     pluginpb.SEVERITY `json:"severity"`
-	ResourceType string            `json:"resource_type"`
+	FuncName     string                 `json:"func_name"`
+	State        pluginpb.STATE         `json:"state"`
+	Msg          string                 `json:"msg"`
+	Severity     pluginpb.SEVERITY      `json:"severity"`
+	ResourceType string                 `json:"resource_type"`
+	Options      map[string]interface{} `json:"options"`
 }
 
 func (r *ReqMsg) UpdateState(stat pluginpb.STATE) {


### PR DESCRIPTION
### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Enhancement
- [ ] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

Add Options in ReqMsg to use unique name in key

**Related:** # (issue)
close #314

**Summary**
previously, only plugin's method name has used as key to store plugins, it would be malfunctional if there's same plugin & method name in config.yaml. It's has been fixed by @gnongs but didn't fix it on pagerduty because it hadn't developed when he send PR.  

This PR fix pagerduty to use a sync.map's key with plugin + address + port so it fix use method name as key in pagerduty.go

---

### 3. Comments
> Please, leave a comments if there's further action that requires. 