### PR TITLE
#322: Redirect plugin's log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ cover.out
 vatz
 default.yaml
 
+*.log
 
 /.idea/modules.xml
 /.idea/vatz.iml

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -110,7 +110,7 @@ var (
 				logfile = fmt.Sprintf("%s/%s.log", pluginDir, pluginName)
 			}
 
-			f, err := os.OpenFile(logfile, os.O_RDWR|os.O_CREATE, 0644)
+			f, err := os.OpenFile(logfile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
 			if err != nil {
 				log.Info().Str("module", "plugin").Err(err)
 				return err

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -105,8 +105,21 @@ var (
 
 			log.Info().Str("module", "plugin").Msgf("Start plugin %s %s", pluginName, exeArgs)
 
+			logfile := viper.GetString("log")
+			if logfile == "" {
+				logfile = fmt.Sprintf("%s/%s.log", pluginDir, pluginName)
+			}
+
+			f, err := os.OpenFile(logfile, os.O_RDWR|os.O_CREATE, 0644)
+			if err != nil {
+				log.Info().Str("module", "plugin").Err(err)
+				return err
+			}
+
+			log.Info().Str("module", "plugin").Msgf("Plugin log redirect to %s", logfile)
+
 			mgr := plugin.NewManager(pluginDir)
-			return mgr.Start(pluginName, exeArgs)
+			return mgr.Start(pluginName, exeArgs, f)
 		},
 	}
 
@@ -152,9 +165,11 @@ func createPluginCommand() *cobra.Command {
 
 	startCommand.PersistentFlags().StringP("plugin", "p", "", "Installed plugin name")
 	startCommand.PersistentFlags().StringP("args", "a", "", "Arguments")
+	startCommand.PersistentFlags().StringP("log", "l", "", "Logfile")
 
 	viper.BindPFlag("plugin", startCommand.PersistentFlags().Lookup("plugin"))
 	viper.BindPFlag("args", startCommand.PersistentFlags().Lookup("args"))
+	viper.BindPFlag("log", startCommand.PersistentFlags().Lookup("log"))
 
 	cmd.AddCommand(statusCommand)
 	cmd.AddCommand(installCommand)

--- a/manager/plugin/plugin.go
+++ b/manager/plugin/plugin.go
@@ -33,7 +33,7 @@ type VatzPluginManager interface {
 
 	Update() error
 
-	Start(name, args string) error
+	Start(name, args string, logfile *os.File) error
 }
 
 type vatzPluginManager struct {
@@ -133,10 +133,8 @@ func (m *vatzPluginManager) Update() error {
 	return nil
 }
 
-func (m *vatzPluginManager) Start(name, args string) error {
+func (m *vatzPluginManager) Start(name, args string, logfile *os.File) error {
 	log.Info().Str("module", "plugin").Msgf("Start plugin %s", name)
-
-	// TODO: How to handle log?
 
 	dbRd, err := newReader(fmt.Sprintf("%s/%s", m.home, pluginDBName))
 	if err != nil {
@@ -149,6 +147,8 @@ func (m *vatzPluginManager) Start(name, args string) error {
 	}
 
 	cmd := exec.Command(e.BinaryLocation, args)
+	cmd.Stdout = logfile
+
 	return cmd.Start()
 }
 

--- a/manager/plugin/plugin_test.go
+++ b/manager/plugin/plugin_test.go
@@ -35,7 +35,14 @@ func TestPluginManager(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Test Execute
-	err = mgr.Start(binName, "-valoperAddr=dummy")
+	logfile, err := os.OpenFile("./vatz.log", os.O_RDWR|os.O_CREATE, 0644)
+	assert.Nil(t, err)
+
+	defer func() {
+		os.Remove("./vatz..log")
+	}()
+
+	err = mgr.Start(binName, "-valoperAddr=dummy", logfile)
 	assert.Nil(t, err)
 
 	// Test DB.


### PR DESCRIPTION
### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Enhancement
- [ ] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

**Related:** # (issue)

close #322 

**Summary**

If the plugin is started by `vatz plugin` command, the output log will be stacked file.

By default, the log file will be created at vatz's plugin directory($HOME/.vatz)
and the file name will be same to plugin's name.

But the user specify `--log` argument like below, the log file will be created at exact location.

```
rootwarp@mindhack ~/g/vatz log > ./vatz plugin start --plugin cosmos-status --args "--valoperAddr=cosmosvaloper1wlagucxdxvsmvj6330864x8q3vxz4x02rmvmsu" --log ./status.log
```

The log file will be created if the log file is not exist or the log contents will be appended into the old file.

---

### 3. Comments
> Please, leave a comments if there's further action that requires. 