### PR TITLE
Add new official icons for VATZ 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <br/>  
 <div align="center" style="display:flex;">  
-  <img width="400" alt="v_black_square_800px" src="https://user-images.githubusercontent.com/6308023/220511474-d403b287-2e51-4bbb-a13f-9e0e5bef8b38.svg">
+  <img width="800" alt="v_black_square_800px" src="https://user-images.githubusercontent.com/6308023/220511474-d403b287-2e51-4bbb-a13f-9e0e5bef8b38.svg">
 
   <p> 
     <br>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <br/>  
 <div align="center" style="display:flex;">  
-  <img width="400" alt="v_black_square_800px" src="https://user-images.githubusercontent.com/63234878/209922215-cccf7b88-de12-42ac-9714-8a5e3f194d7f.png">
+  <img width="400" alt="v_black_square_800px" src="https://user-images.githubusercontent.com/6308023/220511474-d403b287-2e51-4bbb-a13f-9e0e5bef8b38.svg">
 
   <p> 
     <br>

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -13,7 +13,9 @@ func createVersionCommand() *cobra.Command {
 		Short: "VATZ Version",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			verStr := utils.GetVersion()
-			fmt.Println(verStr)
+			fmt.Println("                                                                        \n   @@@@@@@@@@@@@@@         @@@@@@@@@@@@@@@@@@@                  \n    #@@@@@@@@@@@@@@@           @@@@@@@@@@@@@.                   \n      @@@@@@@@@@@@@@@              &@@@@@@@                     \n       @@@@@@@@@@@@@@@&            ,@@@@@.                      \n         @@@@@@@@@@@@@@@           ,@@@@                        \n          @@@@@@@@@@@@@@@(         ,@@/                         \n           .@@@@@@@@@@@@@@@        ,@                           \n             @@@@@@@@@@@@@@@.      .                            \n              *@@@@@@@@@@@@@@@                                  \n                @@@@@@@@@@@@@@@.                                \n                 &@@@@@@@@@@@@@@                                \n                   @@@@@@@@@@@                                  \n                    @@@@@@@@%                                   \n                      @@@@@                                     \n                       @@*    VATZ dsrv labs Co., Ltd. ")
+			fmt.Println("")
+			fmt.Println("VATZ Version: " + verStr)
 			return nil
 		},
 	}


### PR DESCRIPTION
### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Enhancement
- [ ] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

close #405 

**Summary**

Add a new official icons from @Jihoo-Designer and add Ascii mark on CLI command `version`

<img width="907" alt="image" src="https://user-images.githubusercontent.com/6308023/220518253-cad3a1ea-564b-4039-8689-7cb151563480.png">


```
 dongyookang DK 🚀   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-405 ±
 ./vatz version
                                                                        
   @@@@@@@@@@@@@@@         @@@@@@@@@@@@@@@@@@@                  
    #@@@@@@@@@@@@@@@           @@@@@@@@@@@@@.                   
      @@@@@@@@@@@@@@@              &@@@@@@@                     
       @@@@@@@@@@@@@@@&            ,@@@@@.                      
         @@@@@@@@@@@@@@@           ,@@@@                        
          @@@@@@@@@@@@@@@(         ,@@/                         
           .@@@@@@@@@@@@@@@        ,@                           
             @@@@@@@@@@@@@@@.      .                            
              *@@@@@@@@@@@@@@@                                  
                @@@@@@@@@@@@@@@.                                
                 &@@@@@@@@@@@@@@                                
                   @@@@@@@@@@@                                  
                    @@@@@@@@%                                   
                      @@@@@                                     
                       @@*    VATZ dsrv labs Co., Ltd. 

VATZ Version: ISSUE-405-51b4123

```