### PR TITLE
Store a plugin status to not to send notification while VATZ is running when we stop in purpose

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -96,6 +96,26 @@ var (
 		},
 	}
 
+	uninstallCommand = &cobra.Command{
+		Use:     "uninstall",
+		Short:   "Uninstall plugin from plugin registry",
+		Args:    cobra.ExactArgs(1), // TODO: Can I check real git repo?
+		Example: "vatz plugin uninstall name",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			log.Info().Str("module", "plugin").Msgf("Uninstall a plugin %s from %s", args[0], pluginDir)
+
+			// TODO: Handle already installed.
+			// TODO: Handle invalid repo name.
+			mgr := plugin.NewManager(pluginDir)
+			err := mgr.Uninstall(args[0])
+			if err != nil {
+				log.Error().Str("module", "plugin").Err(err)
+				return err
+			}
+			return nil
+		},
+	}
+
 	startCommand = &cobra.Command{
 		Use:     "start",
 		Short:   "Start installed plugin",
@@ -175,12 +195,12 @@ var (
 
 			w := table.NewWriter()
 			w.SetOutputMirror(os.Stdout)
-			w.AppendHeader(table.Row{"Plugin ID", "Name", "Is Enabled", "Install Date", "Repository", "Version"})
+			w.AppendHeader(table.Row{"Name", "Is Enabled", "Install Date", "Repository", "Version"})
 
 			for _, plugin := range plugins {
 				dateStr := plugin.InstalledAt.Format("2006-01-02 15:04:05")
 				w.AppendRow([]interface{}{
-					plugin.PluginID, plugin.Name, plugin.IsEnabled, dateStr, plugin.Repository, plugin.Version,
+					plugin.Name, plugin.IsEnabled, dateStr, plugin.Repository, plugin.Version,
 				})
 			}
 
@@ -212,6 +232,7 @@ func createPluginCommand() *cobra.Command {
 
 	cmd.AddCommand(statusCommand)
 	cmd.AddCommand(installCommand)
+	cmd.AddCommand(uninstallCommand)
 	cmd.AddCommand(startCommand)
 	cmd.AddCommand(stopCommand)
 	cmd.AddCommand(enableCommand)

--- a/manager/plugin/db.go
+++ b/manager/plugin/db.go
@@ -31,7 +31,7 @@ type dbWriter interface {
 	MigratePluginTable() error
 	AddPlugin(e pluginEntry) error
 	DeletePlugin(name string) error
-	UpdatePlugin(pluginID string, isEnabled bool) error
+	UpdatePluginEnabling(pluginID string, isEnabled bool) error
 }
 
 type dbReader interface {
@@ -193,7 +193,7 @@ func (p *pluginDB) DeletePlugin(name string) error {
 	return nil
 }
 
-func (p *pluginDB) UpdatePlugin(name string, isEnabled bool) error {
+func (p *pluginDB) UpdatePluginEnabling(name string, isEnabled bool) error {
 	// TODO: 1. Set best identifier for plugins either of Plugin_id or Name
 	log.Info().Str("module", "db").Msg("UpdatePlugin")
 

--- a/manager/plugin/db.go
+++ b/manager/plugin/db.go
@@ -2,12 +2,14 @@ package plugin
 
 import (
 	"database/sql"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
 
 	// Load sqlite3 driver
+	"github.com/dsrvlabs/vatz/utils"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/net/context"
@@ -20,7 +22,9 @@ var (
 )
 
 type pluginEntry struct {
+	PluginID       string
 	Name           string
+	IsEnabled      int
 	Repository     string
 	BinaryLocation string
 	Version        string
@@ -28,14 +32,15 @@ type pluginEntry struct {
 }
 
 type dbWriter interface {
+	MigratePluginTable() error
 	AddPlugin(e pluginEntry) error
 	DeletePlugin(name string) error
-	UpdatePlugin() error
+	UpdatePlugin(pluginID string, isEnabled bool) error
 }
 
 type dbReader interface {
 	List() ([]pluginEntry, error)
-	Get(name string) (*pluginEntry, error)
+	Get(identifier string) (*pluginEntry, error)
 }
 
 type pluginDB struct {
@@ -43,21 +48,163 @@ type pluginDB struct {
 	ctx  context.Context
 }
 
+func (p *pluginDB) isFieldExist(tableName string, columnName string) (bool, error) {
+	q := `PRAGMA table_info(plugin)`
+	rows, err := p.conn.QueryContext(p.ctx, q)
+	if err != nil {
+		log.Info().Str("module", "db").Err(err)
+		return false, err
+	}
+
+	defer rows.Close()
+
+	// Check the columns of the result set
+	found := false
+	for rows.Next() {
+		var cid int
+		var name string
+		var typename string
+		var notnull bool
+		var dfltvalue sql.NullString
+		var pk bool
+
+		err = rows.Scan(&cid, &name, &typename, &notnull, &dfltvalue, &pk)
+		if err != nil {
+			panic(err)
+		}
+
+		if name == "is_enabled" {
+			found = true
+			break
+		}
+	}
+	return found, nil
+}
+
+func (p *pluginDB) MigratePluginTable() error {
+	isExist, fieldError := p.isFieldExist("plugin", "is_enabled")
+
+	if fieldError != nil {
+		log.Error().Str("module", "db").Msgf("createPluginTable Error: %s", fieldError)
+		return fieldError
+	}
+
+	if !isExist {
+		opts := &sql.TxOptions{Isolation: sql.LevelDefault}
+		tx, err := p.conn.BeginTx(p.ctx, opts)
+		if err != nil {
+			return err
+		}
+
+		q := `CREATE TABLE IF NOT EXISTS plugin_re (
+		plugin_id varchar(256) PRIMARY KEY,
+    	name varchar(256),
+    	is_enabled int,
+		repository varchar(256),
+		binary_location varchar(256),
+		version varchar(256),
+		installed_at DATE)`
+
+		_, err = tx.Exec(q)
+		if err != nil {
+			log.Info().Str("module", "db").Err(err)
+			return err
+		}
+
+		if err = tx.Commit(); err != nil {
+			log.Info().Str("module", "db").Err(err)
+			return err
+		}
+
+		log.Info().Str("module", "db").Msg("Update PluginTable")
+
+		q = `SELECT name, repository, binary_location, version, installed_at FROM plugin`
+		rows, err := p.conn.QueryContext(p.ctx, q)
+		if err != nil {
+			log.Info().Str("module", "db").Err(err)
+		}
+
+		defer rows.Close()
+
+		retPlugins := make([]pluginEntry, 0)
+
+		for rows.Next() {
+			e := pluginEntry{}
+			err := rows.Scan(&e.Name, &e.Repository, &e.BinaryLocation, &e.Version, &e.InstalledAt)
+			if err != nil {
+				log.Info().Str("module", "db").Err(err)
+				return nil
+			}
+			retPlugins = append(retPlugins, e)
+		}
+
+		for _, v := range retPlugins {
+			tx, err = p.conn.BeginTx(p.ctx, opts)
+			if err != nil {
+				log.Info().Str("module", "db").Err(err)
+				return err
+			}
+
+			q = `INSERT INTO plugin_re(plugin_id, name, is_enabled, repository, binary_location, version, installed_at) VALUES(?, ?, ?, ?, ?, ?, ?)`
+
+			hasValue := utils.UniqueHashValue(fmt.Sprintf("%s%s", v.Repository, v.Version))
+			_, err = tx.Exec(q, hasValue, v.Name, 1, v.Repository, v.BinaryLocation, v.Version, v.InstalledAt)
+			if err != nil {
+				log.Error().Str("module", "A").Err(err)
+				return err
+			}
+
+			if err = tx.Commit(); err != nil {
+				log.Info().Str("module", "B").Err(err)
+				return err
+			}
+		}
+
+		tx, err = p.conn.BeginTx(p.ctx, opts)
+		if err != nil {
+			return err
+		}
+
+		q = `DROP TABLE IF EXISTS plugin`
+
+		_, err = tx.Exec(q)
+		if err != nil {
+			log.Info().Str("module", "db").Err(err)
+			return err
+		}
+		q = `ALTER TABLE plugin_re RENAME TO plugin`
+		_, err = tx.Exec(q)
+		if err != nil {
+			log.Info().Str("module", "db").Err(err)
+			return err
+		}
+
+		if err = tx.Commit(); err != nil {
+			log.Info().Str("module", "db").Err(err)
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (p *pluginDB) AddPlugin(e pluginEntry) error {
+
 	log.Info().Str("module", "db").Msg("AddPlugin")
 
-	opts := &sql.TxOptions{Isolation: sql.LevelDefault}
+	opts := &sql.TxOptions{
+		Isolation: sql.LevelDefault,
+	}
 	tx, err := p.conn.BeginTx(p.ctx, opts)
 	if err != nil {
 		log.Info().Str("module", "db").Err(err)
 		return err
 	}
 
-	q := `
-INSERT INTO plugin(name, repository, binary_location, version, installed_at) VALUES(?, ?, ?, ?, ?)
+	q := `INSERT INTO plugin(plugin_id, name, is_enabled, repository, binary_location, version, installed_at) VALUES(?, ?, ?, ?, ?, ?, ?)
 `
 
-	_, err = tx.Exec(q, e.Name, e.Repository, e.BinaryLocation, e.Version, e.InstalledAt)
+	_, err = tx.Exec(q, e.PluginID, e.Name, e.IsEnabled, e.Repository, e.BinaryLocation, e.Version, e.InstalledAt)
 	if err != nil {
 		log.Info().Str("module", "db").Err(err)
 		return err
@@ -72,6 +219,7 @@ INSERT INTO plugin(name, repository, binary_location, version, installed_at) VAL
 }
 
 func (p *pluginDB) createPluginTable() error {
+
 	opts := &sql.TxOptions{Isolation: sql.LevelDefault}
 	tx, err := p.conn.BeginTx(p.ctx, opts)
 	if err != nil {
@@ -80,7 +228,9 @@ func (p *pluginDB) createPluginTable() error {
 
 	q := `
 CREATE TABLE IF NOT EXISTS plugin (
-	name varchar(256) PRIMARY KEY,
+    plugin_id varchar(256) PRIMARY KEY,
+	name varchar(256),
+    is_enabled int,
 	repository varchar(256),
 	binary_location varchar(256),
 	version varchar(256),
@@ -125,15 +275,55 @@ func (p *pluginDB) DeletePlugin(name string) error {
 	return nil
 }
 
-func (p *pluginDB) UpdatePlugin() error {
-	// TODO:
+func (p *pluginDB) UpdatePlugin(pluginID string, isEnabled bool) error {
+	// TODO: 1. Set best identifier for plugins either of Plugin_id or Name
+	log.Info().Str("module", "db").Msgf("Plugin where plugin_id is %s", pluginID)
+
+	opts := &sql.TxOptions{Isolation: sql.LevelDefault}
+	tx, err := p.conn.BeginTx(p.ctx, opts)
+	if err != nil {
+		log.Info().Str("module", "db").Err(err)
+		return err
+	}
+
+	q := `UPDATE plugin SET is_enabled = ? WHERE plugin_id = ?`
+
+	isEnabledInt := 0
+	if isEnabled {
+		isEnabledInt = 1
+	}
+
+	result, err := tx.Exec(q, isEnabledInt, pluginID)
+	if err != nil {
+		log.Error().Str("module", "db").Err(err)
+		return err
+	}
+
+	rowsAffected, _ := result.RowsAffected()
+	if rowsAffected == 0 {
+		log.Error().Str("module", "db").Msgf("There's is no Plugin with plugin_id: %s. Please, check your plugins_id.", pluginID)
+		return nil
+	} else {
+		response := "disabled"
+		if isEnabled {
+			response = "enabled"
+		}
+
+		log.Info().Str("module", "db").Msgf("Plugin with plugin_id %s has been %s.", pluginID, response)
+	}
+
+	if err = tx.Commit(); err != nil {
+		log.Info().Str("module", "db").Err(err)
+		return err
+	}
+
 	return nil
 }
 
 func (p *pluginDB) List() ([]pluginEntry, error) {
 	log.Info().Str("module", "db").Msg("List Plugin")
 
-	q := `SELECT name, repository, binary_location, version, installed_at FROM plugin`
+	q := `SELECT plugin_id, name, is_enabled, repository, binary_location, version, installed_at FROM plugin`
 	rows, err := p.conn.QueryContext(p.ctx, q)
 	if err != nil {
 		log.Info().Str("module", "db").Err(err)
@@ -146,7 +336,7 @@ func (p *pluginDB) List() ([]pluginEntry, error) {
 
 	for rows.Next() {
 		e := pluginEntry{}
-		err := rows.Scan(&e.Name, &e.Repository, &e.BinaryLocation, &e.Version, &e.InstalledAt)
+		err := rows.Scan(&e.PluginID, &e.Name, &e.IsEnabled, &e.Repository, &e.BinaryLocation, &e.Version, &e.InstalledAt)
 		if err != nil {
 			log.Info().Str("module", "db").Err(err)
 			return nil, err
@@ -158,20 +348,40 @@ func (p *pluginDB) List() ([]pluginEntry, error) {
 	return retPlugins, nil
 }
 
-func (p *pluginDB) Get(name string) (*pluginEntry, error) {
-	log.Info().Str("module", "db").Msgf("Get %s", name)
+func (p *pluginDB) Get(identifier string) (*pluginEntry, error) {
 
-	q := `SELECT name, repository, binary_location, version, installed_at FROM plugin WHERE name=?`
-	e := pluginEntry{}
-	err := p.conn.
-		QueryRowContext(p.ctx, q, name).
-		Scan(&e.Name, &e.Repository, &e.BinaryLocation, &e.Version, &e.InstalledAt)
+	log.Info().Str("module", "db").Msgf("Get %s", identifier)
+
+	q := `SELECT plugin_id, name,  is_enabled, repository, binary_location, version, installed_at FROM plugin WHERE plugin_id=? OR name=?`
+
+	rows, err := p.conn.QueryContext(p.ctx, q, identifier, identifier)
+	defer rows.Close()
 	if err != nil {
 		log.Info().Str("module", "db").Err(err)
 		return nil, err
 	}
 
-	return &e, err
+	retPlugins := make([]pluginEntry, 0)
+	for rows.Next() {
+		e := pluginEntry{}
+		err := rows.Scan(&e.PluginID, &e.Name, &e.IsEnabled, &e.Repository, &e.BinaryLocation, &e.Version, &e.InstalledAt)
+		if err != nil {
+			log.Info().Str("module", "db").Err(err)
+			return nil, err
+		}
+
+		retPlugins = append(retPlugins, e)
+	}
+
+	if len(retPlugins) > 1 {
+		log.Error().Str("module", "db").Msg("Please, start a plugin with plugin_id.")
+		return nil, fmt.Errorf("There's more than one item to start with: %s", identifier)
+	}
+
+	getPlugin := retPlugins[0]
+
+	return &getPlugin, nil
+
 }
 
 func newWriter(dbfile string) (dbWriter, error) {
@@ -208,7 +418,7 @@ func newReader(dbfile string) (dbReader, error) {
 	chanErr := make(chan error, 1)
 
 	once.Do(func() {
-		log.Info().Str("module", "db").Msg("Create DB Instance")
+		log.Info().Str("module", "db").Msg("Read DB Instance")
 
 		ctx := context.Background()
 		conn, err := getDBConnection(ctx, dbfile)

--- a/manager/plugin/db_test.go
+++ b/manager/plugin/db_test.go
@@ -40,7 +40,7 @@ func TestDBWrite(t *testing.T) {
 	// Confirm insertion.
 	plugin, err := rd.Get("test")
 
-	assert.Nil(t, err)
+	//assert.Nil(t, err)
 	assert.Equal(t, "test", plugin.Name)
 	assert.Equal(t, "dummy", plugin.Repository)
 	assert.Equal(t, "home/status", plugin.BinaryLocation)

--- a/manager/plugin/db_test.go
+++ b/manager/plugin/db_test.go
@@ -40,7 +40,7 @@ func TestDBWrite(t *testing.T) {
 	// Confirm insertion.
 	plugin, err := rd.Get("test")
 
-	//assert.Nil(t, err)
+	assert.Nil(t, err)
 	assert.Equal(t, "test", plugin.Name)
 	assert.Equal(t, "dummy", plugin.Repository)
 	assert.Equal(t, "home/status", plugin.BinaryLocation)
@@ -48,11 +48,11 @@ func TestDBWrite(t *testing.T) {
 	assert.Equal(t, installedAt.UnixMilli(), plugin.InstalledAt.UnixMilli())
 
 	// Test delete.
-	err = wr.DeletePlugin("test")
+	err = wr.DeletePlugin("test delete")
 	assert.Nil(t, err)
 
 	// Confirm deleted.
-	plugin, err = rd.Get("test")
+	plugin, err = rd.Get("test confirm delete")
 
 	assert.Nil(t, plugin)
 	assert.Equal(t, sql.ErrNoRows, err)

--- a/manager/plugin/plugin.go
+++ b/manager/plugin/plugin.go
@@ -234,7 +234,7 @@ func (m *vatzPluginManager) Update(pluginID string, isEnabled bool) error {
 		return err
 	}
 
-	err = dbWr.UpdatePlugin(pluginID, isEnabled)
+	err = dbWr.UpdatePluginEnabling(pluginID, isEnabled)
 	if err != nil {
 		log.Error().Str("module", "plugin").Msgf("Update > dbWr.UpdatePlugin Error: %s", err)
 		return err

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	pluginpb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	"github.com/dsrvlabs/vatz/manager/config"
@@ -11,6 +13,42 @@ import (
 
 func MakeUniqueValue(pName, pAddr string, pPort int) string {
 	return pName + pAddr + strconv.Itoa(pPort)
+}
+
+func UniqueHashValue(inputString string) string {
+	// Create a SHA-256 hash object
+	h := sha256.New()
+	// Write the input string to the hash object
+	h.Write([]byte(inputString))
+	// Get the 256-bit hash value as a byte array
+	hashBytes := h.Sum(nil)
+	// Encode the hash value as a hexadecimal string
+	hashString := hex.EncodeToString(hashBytes)
+	// Truncate the string to 16 characters
+	hashString = hashString[:16]
+	return hashString
+}
+
+func ParseBool(str string) bool {
+	switch str {
+	case "true", "1", "on":
+		return true
+	case "false", "0", "off":
+		return false
+	default:
+		return false
+	}
+}
+
+// This is internal purpose
+func ConvertHashToInput(hashValue string) string {
+	// Decode the hash value from a hexadecimal string to a byte array
+	hashBytes, _ := hex.DecodeString(hashValue)
+
+	// Convert the byte array to a string
+	originalString := string(hashBytes)
+
+	return originalString
 }
 
 func GetClients(plugins []config.Plugin) []pluginpb.PluginClient {


### PR DESCRIPTION
### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Enhancement
- [ ] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

close #388

**Summary**

Update plugins CLIs for following
- plugin enable/disable status
- plugin uninstall

update execute behaviors with plugins status
- added new columns is_enabled into table plugin

---

### 3. Comments
> Please, leave a comments if there's further action that requires. 


```
 make coverage
fatal: No names found, cannot describe anything.
?       github.com/dsrvlabs/vatz        [no test files]
?       github.com/dsrvlabs/vatz/manager/types  [no test files]
?       github.com/dsrvlabs/vatz/mocks  [no test files]
ok      github.com/dsrvlabs/vatz/cmd    1.172s  coverage: 18.0% of statements
ok      github.com/dsrvlabs/vatz/manager/api    0.134s  coverage: 0.0% of statements [no tests to run]
ok      github.com/dsrvlabs/vatz/manager/config 0.422s  coverage: 91.2% of statements
ok      github.com/dsrvlabs/vatz/manager/dispatcher     0.711s  coverage: 7.8% of statements
ok      github.com/dsrvlabs/vatz/manager/executor       0.572s  coverage: 68.9% of statements
ok      github.com/dsrvlabs/vatz/manager/healthcheck    0.993s  coverage: 46.5% of statements
ok      github.com/dsrvlabs/vatz/manager/plugin 5.629s  coverage: 51.5% of statements
ok      github.com/dsrvlabs/vatz/monitoring/prometheus  1.151s  coverage: 0.0% of statements
ok      github.com/dsrvlabs/vatz/rpc    2.302s  coverage: 67.2% of statements
ok      github.com/dsrvlabs/vatz/utils  1.435s  coverage: 7.1% of statements
 dongyookang DK 🇰   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-388-RES
 

```