### PR TITLE
Avoid overriding DB while its on coverage test.

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	tp "github.com/dsrvlabs/vatz/manager/types"
 	"github.com/spf13/cobra"
 
 	dp "github.com/dsrvlabs/vatz/manager/dispatcher"
@@ -31,7 +32,7 @@ var (
 // CreateRootCommand creates root command of Cobra.
 func CreateRootCommand() *cobra.Command {
 	rootCmd := &cobra.Command{}
-	rootCmd.AddCommand(createInitCommand())
+	rootCmd.AddCommand(createInitCommand(tp.LIVE))
 	rootCmd.AddCommand(createStartCommand())
 	rootCmd.AddCommand(createPluginCommand())
 	rootCmd.AddCommand(createVersionCommand())

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	tp "github.com/dsrvlabs/vatz/manager/types"
 	"os"
 	"testing"
 
@@ -28,7 +29,7 @@ func TestInitCmd(t *testing.T) {
 
 	for _, test := range tests {
 		root := cobra.Command{}
-		root.AddCommand(createInitCommand())
+		root.AddCommand(createInitCommand(tp.TEST))
 		root.SetArgs(test.Args)
 
 		err := root.Execute()

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	tp "github.com/dsrvlabs/vatz/manager/types"
 	"os"
 
 	"github.com/rs/zerolog/log"
@@ -9,7 +10,7 @@ import (
 	"github.com/dsrvlabs/vatz/manager/plugin"
 )
 
-func createInitCommand() *cobra.Command {
+func createInitCommand(initializer tp.Initializer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Init",
@@ -82,7 +83,7 @@ plugins_infos:
 			}
 
 			mgr := plugin.NewManager(pluginDir)
-			return mgr.Init()
+			return mgr.Init(initializer)
 		},
 	}
 

--- a/manager/plugin/plugin.go
+++ b/manager/plugin/plugin.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	tp "github.com/dsrvlabs/vatz/manager/types"
 	"os"
 	"os/exec"
 	"strings"
@@ -30,7 +31,7 @@ type VatzPlugin struct {
 
 // VatzPluginManager provides management functions for plugin.
 type VatzPluginManager interface {
-	Init() error
+	Init(runType tp.Initializer) error
 
 	Install(repo, name, version string) error
 	List() ([]VatzPlugin, error)
@@ -45,8 +46,12 @@ type vatzPluginManager struct {
 	home string
 }
 
-func (m *vatzPluginManager) Init() error {
-	return initDB(fmt.Sprintf("%s/%s", m.home, pluginDBName))
+func (m *vatzPluginManager) Init(runType tp.Initializer) error {
+	dbName := pluginDBName
+	if runType == tp.TEST {
+		dbName = "vatz-test.db"
+	}
+	return initDB(fmt.Sprintf("%s/%s", m.home, dbName))
 }
 
 func (m *vatzPluginManager) Install(repo, name, version string) error {

--- a/manager/types/cmd.go
+++ b/manager/types/cmd.go
@@ -1,0 +1,8 @@
+package types
+
+type Initializer string
+
+const (
+	TEST Initializer = "TEST"
+	LIVE Initializer = "LIVE"
+)


### PR DESCRIPTION


### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Enhancement
- [x] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

**Related:** # (issue)
close #429

**Summary**

Add initializer for CLI command `init` to avoid overriding while its on coverage test.

---

### 3. Comments
> Please, leave a comments if there's further action that requires. 
go coverage should not affected on VATZ running. 