### PR TITLE
Fix. config instance should be loaded before execute CLI.

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -113,6 +113,10 @@ var (
 		Short:   "Uninstall plugin from plugin registry",
 		Args:    cobra.ExactArgs(1), // TODO: Can I check real git repo?
 		Example: "vatz plugin uninstall name",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			_, err := config.InitConfig(configFile)
+			return err
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pluginDir, err := config.GetConfig().Vatz.AbsoluteHomePath()
 			if err != nil {
@@ -197,6 +201,10 @@ var (
 		Short:   "Enabled or Disable plugin",
 		Args:    cobra.ExactArgs(2), // TODO: Can I check real git repo?
 		Example: "vatz plugin enable <plugin_id> <true/false>",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			_, err := config.InitConfig(configFile)
+			return err
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pluginDir, err := config.GetConfig().Vatz.AbsoluteHomePath()
 			if err != nil {


### PR DESCRIPTION
### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Enhancement
- [x] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

**Related:** # (issue)

close #439 

**Summary**

Fix `uninstall` and `status` command.
`PreRunE` is required on cobra command to instantiate config instance before running the command.

---

### 3. Comments
> Please, leave a comments if there's further action that requires. 