### PR TITLE
Remove flag `--home` in CLI command `vatz init`

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -24,7 +24,7 @@ func TestInitCmd(t *testing.T) {
 		//},
 		{
 			Desc:       "Init with selected filename",
-			Args:       []string{"init", "--output", "hello.yaml", "--home", "./"},
+			Args:       []string{"init", "--output", "hello.yaml"},
 			ExpectFile: "hello.yaml",
 		},
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -27,7 +27,7 @@ func createInitCommand(initializer tp.Initializer) *cobra.Command {
   notification_info:
     host_name: "Put your machine's host name"
     default_reminder_schedule:
-      - "*/30 * * * *"
+      - "*/15 * * * *"
     dispatch_channels:
       - channel: "discord"
         secret: "Put your Discord Webhook"

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/rs/zerolog/log"
@@ -15,7 +14,7 @@ import (
 func createInitCommand(initializer tp.Initializer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
-		Short: "Init",
+		Short: "init",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Info().Str("module", "main").Msg("init")
 
@@ -28,7 +27,7 @@ func createInitCommand(initializer tp.Initializer) *cobra.Command {
   notification_info:
     host_name: "Put your machine's host name"
     default_reminder_schedule:
-      - "*/15 * * * *"
+      - "*/30 * * * *"
     dispatch_channels:
       - channel: "discord"
         secret: "Put your Discord Webhook"
@@ -73,15 +72,7 @@ plugins_infos:
 				return err
 			}
 
-			homePath, err := cmd.Flags().GetString("home")
-			if err != nil {
-				return err
-			}
-
-			template = fmt.Sprintf(template, homePath)
-
 			log.Info().Str("module", "main").Msgf("create file %s", filename)
-			log.Info().Str("module", "main").Msgf("home path %s", homePath)
 
 			f, err := os.Create(filename)
 			if err != nil {
@@ -107,7 +98,6 @@ plugins_infos:
 	}
 
 	_ = cmd.PersistentFlags().StringP("output", "o", defaultFlagConfig, "New config file to create")
-	_ = cmd.PersistentFlags().StringP("home", "p", defaultHomePath, "Home directory of VATZ")
 
 	return cmd
 }


### PR DESCRIPTION
### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Enhancement
- [x] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

close #444 

**Summary**

We do not use --home flag in CLI `vatz init` anymore since homepath is set up in config yaml file. 
- Extended default reminder schedule interval from 15 to 30
- Removed --home setting from command `vatz init`

---
```
 ✘ dongyookang DK 💡   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-444
 make coverage
fatal: No names found, cannot describe anything.
?       github.com/dsrvlabs/vatz        [no test files]
?       github.com/dsrvlabs/vatz/manager/types  [no test files]
?       github.com/dsrvlabs/vatz/mocks  [no test files]
ok      github.com/dsrvlabs/vatz/cmd    1.092s  coverage: 18.3% of statements
ok      github.com/dsrvlabs/vatz/manager/api    0.363s  coverage: 0.0% of statements [no tests to run]
ok      github.com/dsrvlabs/vatz/manager/config 0.500s  coverage: 79.4% of statements
ok      github.com/dsrvlabs/vatz/manager/dispatcher     0.636s  coverage: 7.8% of statements
ok      github.com/dsrvlabs/vatz/manager/executor       1.067s  coverage: 68.9% of statements
ok      github.com/dsrvlabs/vatz/manager/healthcheck    0.770s  coverage: 46.5% of statements
ok      github.com/dsrvlabs/vatz/manager/plugin 5.405s  coverage: 50.6% of statements
ok      github.com/dsrvlabs/vatz/monitoring/prometheus  1.214s  coverage: 0.0% of statements
ok      github.com/dsrvlabs/vatz/rpc    2.496s  coverage: 67.2% of statements
ok      github.com/dsrvlabs/vatz/utils  1.342s  coverage: 7.1% of statements
 dongyookang DK 💡   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-444 ±
 
```