### PR TITLE
Update default reminder interval setting from 15 min to 30 min

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -28,7 +28,7 @@ func createInitCommand(initializer tp.Initializer) *cobra.Command {
   notification_info:
     host_name: "Put your machine's host name"
     default_reminder_schedule:
-      - "*/15 * * * *"
+      - "*/30 * * * *"
     dispatch_channels:
       - channel: "discord"
         secret: "Put your Discord Webhook"


### PR DESCRIPTION
### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Enhancement
- [ ] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

**Related:** # (issue)
close #448 

**Summary**
Update default reminder interval setting from 15 min to 30 min
since minor change will be placed on other PR but creating proper issue and corresponding PR has to be placed for its purpose. 


---

### 3. Comments
> Please, leave a comments if there's further action that requires. 


```
 make build
fatal: No names found, cannot describe anything.
go build -ldflags="-X 'github.com/dsrvlabs/vatz/utils.Version=ISSUE-448' -X 'github.com/dsrvlabs/vatz/utils.Commit=97bb6bd'" -v
github.com/dsrvlabs/vatz
 dongyookang DK ⚡️   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-448 ±
 ./vatz init       
2023-05-24T17:51:34-05:00 INF init module=main
2023-05-24T17:51:34-05:00 INF create file default.yaml module=main
2023-05-24T17:51:34-05:00 INF home path ~/.vatz module=main
2023-05-24T17:51:34-05:00 INF Load Config default.yaml module=config
2023-05-24T17:51:34-05:00 INF Plugin dir /Users/dongyookang/.vatz module=main
2023-05-24T17:51:34-05:00 INF Create DB Instance module=db
2023-05-24T17:51:34-05:00 INF initDB /Users/dongyookang/.vatz/vatz.db module=db
2023-05-24T17:51:34-05:00 INF Remove old DB file module=db
2023-05-24T17:51:34-05:00 INF Create new DB file module=db
2023-05-24T17:51:34-05:00 INF Create DB Instance module=db
 dongyookang DK ⚡️   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-448 ±
 make coverage
fatal: No names found, cannot describe anything.
?       github.com/dsrvlabs/vatz        [no test files]
?       github.com/dsrvlabs/vatz/manager/types  [no test files]
?       github.com/dsrvlabs/vatz/mocks  [no test files]
ok      github.com/dsrvlabs/vatz/cmd    2.706s  coverage: 19.8% of statements
ok      github.com/dsrvlabs/vatz/manager/api    0.497s  coverage: 0.0% of statements [no tests to run]
ok      github.com/dsrvlabs/vatz/manager/config 0.620s  coverage: 79.4% of statements
ok      github.com/dsrvlabs/vatz/manager/dispatcher     0.815s  coverage: 7.8% of statements
ok      github.com/dsrvlabs/vatz/manager/executor       1.075s  coverage: 68.9% of statements
ok      github.com/dsrvlabs/vatz/manager/healthcheck    0.942s  coverage: 46.5% of statements
ok      github.com/dsrvlabs/vatz/manager/plugin 7.295s  coverage: 50.6% of statements
ok      github.com/dsrvlabs/vatz/monitoring/prometheus  1.345s  coverage: 0.0% of statements
ok      github.com/dsrvlabs/vatz/rpc    2.488s  coverage: 67.2% of statements
ok      github.com/dsrvlabs/vatz/utils  0.206s  coverage: 7.1% of statements
 dongyookang DK ⚡️   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-448 ±
 

```