### PR TITLE
Add new flag `--all` on CLI command `vatz init`

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -48,8 +48,8 @@ func createInitCommand(initializer tp.Initializer) *cobra.Command {
       enabled: true
       address: "127.0.0.1"
       port: 18080
-
-plugins_infos:
+`
+			samplePluginOptionTemplate := `plugins_infos:
   default_verify_interval: 15
   default_execute_interval: 30
   default_plugin_name: "vatz-plugin"
@@ -67,6 +67,51 @@ plugins_infos:
       executable_methods:
         - method_name: "sampleMethod2"
 `
+			defaultPluginOptionTemplate := `plugins_infos:
+  default_verify_interval: 15
+  default_execute_interval: 30
+  default_plugin_name: "vatz-plugin"
+  plugins:
+    - plugin_name: "vatz_cpu_monitor"
+      plugin_address: "localhost"
+      plugin_port: 9091
+      executable_methods:
+        - method_name: "cpu_monitor"
+    - plugin_name: "vatz_mem_monitor"
+      plugin_address: "localhost"
+      plugin_port: 9092
+      executable_methods:
+        - method_name: "mem-monitor"
+    - plugin_name: "vatz_disk_monitor"
+      plugin_address: "localhost"
+      plugin_port: 9093
+      executable_methods:
+        - method_name: "disk-monitor"
+    - plugin_name: "vatz_block_sync"
+      plugin_address: "localhost"
+      plugin_port: 10091
+      executable_methods:
+        - method_name: "node_block_sync"
+    - plugin_name: "vatz_node_is_alived"
+      plugin_address: "localhost"
+      plugin_port: 10092
+      executable_methods:
+        - method_name: "node_is_alived"
+    - plugin_name: "vatz_peer_count"
+      plugin_address: "localhost"
+      plugin_port: 10093
+      executable_methods:
+        - method_name: "node_active_status"
+    - plugin_name: "vatz_active_status"
+      plugin_address: "localhost"
+      plugin_port: 10094
+      executable_methods:
+        - method_name: "node_governance_alarm"
+    - plugin_name: "vatz_gov_alarm"
+      plugin_address: "localhost"
+      plugin_port: 10095
+      executable_methods:
+        - method_name: "node_peer_count"`
 			filename, err := cmd.Flags().GetString("output")
 			if err != nil {
 				return err
@@ -79,6 +124,15 @@ plugins_infos:
 				return err
 			}
 
+			configOption, err := cmd.Flags().GetBool("all")
+			if err != nil {
+				return err
+			}
+			if configOption {
+				template = template + defaultPluginOptionTemplate
+			} else {
+				template = template + samplePluginOptionTemplate
+			}
 			_, err = f.WriteString(template)
 			if err != nil {
 				return err
@@ -98,6 +152,7 @@ plugins_infos:
 	}
 
 	_ = cmd.PersistentFlags().StringP("output", "o", defaultFlagConfig, "New config file to create")
+	_ = cmd.PersistentFlags().BoolP("all", "a", false, "Create config yaml with all default setting of official plugins.")
 
 	return cmd
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -81,12 +81,12 @@ func createInitCommand(initializer tp.Initializer) *cobra.Command {
       plugin_address: "localhost"
       plugin_port: 9002
       executable_methods:
-        - method_name: "mem-monitor"
+        - method_name: "mem_monitor"
     - plugin_name: "vatz_disk_monitor"
       plugin_address: "localhost"
       plugin_port: 9003
       executable_methods:
-        - method_name: "disk-monitor"
+        - method_name: "disk_monitor"
     - plugin_name: "vatz_net_monitor"
       plugin_address: "localhost"
       plugin_port: 9004

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -74,42 +74,47 @@ func createInitCommand(initializer tp.Initializer) *cobra.Command {
   plugins:
     - plugin_name: "vatz_cpu_monitor"
       plugin_address: "localhost"
-      plugin_port: 9091
+      plugin_port: 9001
       executable_methods:
         - method_name: "cpu_monitor"
     - plugin_name: "vatz_mem_monitor"
       plugin_address: "localhost"
-      plugin_port: 9092
+      plugin_port: 9002
       executable_methods:
         - method_name: "mem-monitor"
     - plugin_name: "vatz_disk_monitor"
       plugin_address: "localhost"
-      plugin_port: 9093
+      plugin_port: 9003
       executable_methods:
         - method_name: "disk-monitor"
+    - plugin_name: "vatz_net_monitor"
+      plugin_address: "localhost"
+      plugin_port: 9004
+      executable_methods:
+        - method_name: "net_monitor"
     - plugin_name: "vatz_block_sync"
       plugin_address: "localhost"
-      plugin_port: 10091
+      plugin_port: 10001
       executable_methods:
         - method_name: "node_block_sync"
     - plugin_name: "vatz_node_is_alived"
       plugin_address: "localhost"
-      plugin_port: 10092
+      plugin_port: 10002
       executable_methods:
         - method_name: "node_is_alived"
     - plugin_name: "vatz_peer_count"
       plugin_address: "localhost"
-      plugin_port: 10093
+      plugin_port: 10003
       executable_methods:
         - method_name: "node_active_status"
     - plugin_name: "vatz_active_status"
       plugin_address: "localhost"
-      plugin_port: 10094
+      plugin_port: 10004
       executable_methods:
         - method_name: "node_governance_alarm"
     - plugin_name: "vatz_gov_alarm"
       plugin_address: "localhost"
-      plugin_port: 10095
+      plugin_port: 10005
       executable_methods:
         - method_name: "node_peer_count"`
 			filename, err := cmd.Flags().GetString("output")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -106,17 +106,17 @@ func createInitCommand(initializer tp.Initializer) *cobra.Command {
       plugin_address: "localhost"
       plugin_port: 10003
       executable_methods:
-        - method_name: "node_active_status"
+        - method_name: "node_peer_count"
     - plugin_name: "vatz_active_status"
       plugin_address: "localhost"
       plugin_port: 10004
       executable_methods:
-        - method_name: "node_governance_alarm"
+        - method_name: "node_active_status"
     - plugin_name: "vatz_gov_alarm"
       plugin_address: "localhost"
       plugin_port: 10005
       executable_methods:
-        - method_name: "node_peer_count"`
+        - method_name: "node_governance_alarm"`
 			filename, err := cmd.Flags().GetString("output")
 			if err != nil {
 				return err


### PR DESCRIPTION
…ing in config yaml file.

### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Enhancement
- [ ] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.
**Related:** # (issue)
close #436 

**Summary**
develop vatz init that provide official plugins default port numbers and name. 

---

### 3. Comments
> Please, leave a comments if there's further action that requires. 


```
 dongyookang DK 💡   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-436-RE ±
 make coverage                                                                                                                           
fatal: No names found, cannot describe anything.
?       github.com/dsrvlabs/vatz        [no test files]
?       github.com/dsrvlabs/vatz/manager/types  [no test files]
?       github.com/dsrvlabs/vatz/mocks  [no test files]
ok      github.com/dsrvlabs/vatz/cmd    2.357s  coverage: 22.1% of statements
ok      github.com/dsrvlabs/vatz/manager/api    0.501s  coverage: 0.0% of statements [no tests to run]
ok      github.com/dsrvlabs/vatz/manager/config 0.768s  coverage: 79.4% of statements
ok      github.com/dsrvlabs/vatz/manager/dispatcher     0.633s  coverage: 7.8% of statements
ok      github.com/dsrvlabs/vatz/manager/executor       1.044s  coverage: 68.9% of statements
ok      github.com/dsrvlabs/vatz/manager/healthcheck    0.900s  coverage: 46.5% of statements
ok      github.com/dsrvlabs/vatz/manager/plugin 6.744s  coverage: 50.6% of statements
ok      github.com/dsrvlabs/vatz/monitoring/prometheus  1.181s  coverage: 0.0% of statements
ok      github.com/dsrvlabs/vatz/rpc    2.490s  coverage: 67.2% of statements
ok      github.com/dsrvlabs/vatz/utils  0.202s  coverage: 7.1% of statements
 dongyookang DK 💡   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-436-RE ±
```