### PR TITLE
- Revert back the Home path in CLI that gives user to set their home_…

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -24,7 +24,7 @@ func TestInitCmd(t *testing.T) {
 		//},
 		{
 			Desc:       "Init with selected filename",
-			Args:       []string{"init", "--output", "hello.yaml"},
+			Args:       []string{"init", "--output", "hello.yaml", "--home", "./"},
 			ExpectFile: "hello.yaml",
 		},
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/rs/zerolog/log"
@@ -72,6 +73,13 @@ plugins_infos:
 				return err
 			}
 
+			homePath, err := cmd.Flags().GetString("home")
+			if err != nil {
+				return err
+			}
+
+			template = fmt.Sprintf(template, homePath)
+			log.Info().Str("module", "main").Msgf("home path %s", homePath)
 			log.Info().Str("module", "main").Msgf("create file %s", filename)
 
 			f, err := os.Create(filename)
@@ -98,6 +106,7 @@ plugins_infos:
 	}
 
 	_ = cmd.PersistentFlags().StringP("output", "o", defaultFlagConfig, "New config file to create")
+	_ = cmd.PersistentFlags().StringP("home", "p", defaultHomePath, "Home directory of VATZ")
 
 	return cmd
 }


### PR DESCRIPTION
…path with given flags `--home`

### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Enhancement
- [x] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

**Related:** # (issue)
close #458

**Summary**

There was a mis understanding on flags for `vatz init` command
`--home` must placed to set home_path by User otherwise it would create VATZ home inside of source code.  

---

### 3. Comments
> Please, leave a comments if there's further action that requires. 

```
 make coverage
fatal: No names found, cannot describe anything.
?       github.com/dsrvlabs/vatz        [no test files]
?       github.com/dsrvlabs/vatz/manager/types  [no test files]
?       github.com/dsrvlabs/vatz/mocks  [no test files]
ok      github.com/dsrvlabs/vatz/cmd    0.987s  coverage: 21.6% of statements
ok      github.com/dsrvlabs/vatz/manager/api    0.731s  coverage: 0.0% of statements [no tests to run]
ok      github.com/dsrvlabs/vatz/manager/config 1.222s  coverage: 79.4% of statements
ok      github.com/dsrvlabs/vatz/manager/dispatcher     1.882s  coverage: 7.8% of statements
ok      github.com/dsrvlabs/vatz/manager/executor       1.406s  coverage: 68.9% of statements
ok      github.com/dsrvlabs/vatz/manager/healthcheck    1.585s  coverage: 46.5% of statements
ok      github.com/dsrvlabs/vatz/manager/plugin 8.416s  coverage: 50.6% of statements
ok      github.com/dsrvlabs/vatz/monitoring/prometheus  2.713s  coverage: 0.0% of statements
ok      github.com/dsrvlabs/vatz/rpc    3.905s  coverage: 67.2% of statements
ok      github.com/dsrvlabs/vatz/utils  3.076s  coverage: 7.1% of statements
 dongyookang DK 🚀   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-458
 

```