### PR TITLE
Check the cron entry initialized in dispatcher

### DIFF
--- a/manager/dispatcher/discord.go
+++ b/manager/dispatcher/discord.go
@@ -64,19 +64,9 @@ func (d *discord) SetDispatcher(firstRunMsg bool, preStat tp.StateFlag, notifyIn
 		d.entry.Store(pUnique, newEntries)
 		d.reminderCron.Start()
 	} else if reminderState == tp.OFF {
-		count := 0
-		d.entry.Range(func(_, _ interface{}) bool {
-			count++
-			return true
-		})
-		if count == 0 {
-			log.Debug().Str("module", "dispatcher").Msg("There's no entry for the cron.")
-			return nil
-		}
-
 		entries, _ := d.entry.Load(pUnique)
-		for _, entity := range entries.([]cron.EntryID) {
-			{
+		if _, ok := entries.([]cron.EntryID); ok {
+			for _, entity := range entries.([]cron.EntryID) {
 				d.reminderCron.Remove(entity)
 			}
 			d.reminderCron.Stop()

--- a/manager/dispatcher/discord.go
+++ b/manager/dispatcher/discord.go
@@ -64,6 +64,16 @@ func (d *discord) SetDispatcher(firstRunMsg bool, preStat tp.StateFlag, notifyIn
 		d.entry.Store(pUnique, newEntries)
 		d.reminderCron.Start()
 	} else if reminderState == tp.OFF {
+		count := 0
+		d.entry.Range(func(_, _ interface{}) bool {
+			count++
+			return true
+		})
+		if count == 0 {
+			log.Debug().Str("module", "dispatcher").Msg("There's no entry for the cron.")
+			return nil
+		}
+
 		entries, _ := d.entry.Load(pUnique)
 		for _, entity := range entries.([]cron.EntryID) {
 			{

--- a/manager/dispatcher/telegram.go
+++ b/manager/dispatcher/telegram.go
@@ -56,6 +56,16 @@ func (t *telegram) SetDispatcher(firstRunMsg bool, preStat tp.StateFlag, notifyI
 		t.entry.Store(pUnique, newEntries)
 		t.reminderCron.Start()
 	} else if reminderState == tp.OFF {
+		count := 0
+		t.entry.Range(func(_, _ interface{}) bool {
+			count++
+			return true
+		})
+		if count == 0 {
+			log.Debug().Str("module", "dispatcher").Msg("There's no entry for the cron.")
+			return nil
+		}
+
 		entries, _ := t.entry.Load(pUnique)
 		for _, entity := range entries.([]cron.EntryID) {
 			t.reminderCron.Remove(entity)

--- a/manager/dispatcher/telegram.go
+++ b/manager/dispatcher/telegram.go
@@ -56,21 +56,13 @@ func (t *telegram) SetDispatcher(firstRunMsg bool, preStat tp.StateFlag, notifyI
 		t.entry.Store(pUnique, newEntries)
 		t.reminderCron.Start()
 	} else if reminderState == tp.OFF {
-		count := 0
-		t.entry.Range(func(_, _ interface{}) bool {
-			count++
-			return true
-		})
-		if count == 0 {
-			log.Debug().Str("module", "dispatcher").Msg("There's no entry for the cron.")
-			return nil
-		}
-
 		entries, _ := t.entry.Load(pUnique)
-		for _, entity := range entries.([]cron.EntryID) {
-			t.reminderCron.Remove(entity)
+		if _, ok := entries.([]cron.EntryID); ok {
+			for _, entity := range entries.([]cron.EntryID) {
+				t.reminderCron.Remove(entity)
+			}
+			t.reminderCron.Stop()
 		}
-		t.reminderCron.Stop()
 	}
 	return nil
 }


### PR DESCRIPTION
### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Enhancement
- [X] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

**Related:** # (issue)
Close #465 

**Summary**
If there's no cron entry was initialized and reminderState was off too, it could be cause panic as below.
This patch allowed to remove and stop the cron job, only if it is exist.
```
panic: interface conversion: interface {} is nil, not []cron.EntryID


goroutine 41 [running]:
github.com/dsrvlabs/vatz/manager/dispatcher.(*telegram).SetDispatcher(0xc000138600, 0x30?, {0xc0?, 0x9c821a?}, {{0xc00013e8d0, 0x10}, {0xc00013e930, 0xb}, {0xc00013e8f0, 0x9}, ...})
	/root/git/vatz/manager/dispatcher/telegram.go:60 +0x37a
github.com/dsrvlabs/vatz/manager/executor.(*executor).Execute(0xedc0b7210?, {0xe1da48, 0xc00003a120}, {0xe1a338, 0xc0002bd230}, {{0xc00013e8d0, 0x10}, {0xc00013e8f0, 0x9}, 0xf, ...}, ...)
	/root/git/vatz/manager/executor/general_executor.go:57 +0x59f
github.com/dsrvlabs/vatz/cmd.multiPluginExecutor({{0xc00013e8d0, 0x10}, {0xc00013e8f0, 0x9}, 0xf, 0x1e, 0x232c, {0xc00011f4f0, 0x1, 0x1}}, ...)
	/root/git/vatz/cmd/start.go:169 +0x39e
created by github.com/dsrvlabs/vatz/cmd.startExecutor
	/root/git/vatz/cmd/start.go:135 +0x87
```

---

### 3. Comments
> Please, leave a comments if there's further action that requires. 
```
heejinlee@Heejinui-MacBookPro:~/Working/dsrvlabs/vatz $ make coverage
fatal: No names found, cannot describe anything.
?   	github.com/dsrvlabs/vatz	[no test files]
ok  	github.com/dsrvlabs/vatz/cmd	1.700s	coverage: 23.5% of statements
ok  	github.com/dsrvlabs/vatz/manager/api	0.250s	coverage: 0.0% of statements [no tests to run]
ok  	github.com/dsrvlabs/vatz/manager/config	0.341s	coverage: 79.4% of statements
ok  	github.com/dsrvlabs/vatz/manager/dispatcher	0.661s	coverage: 7.3% of statements
ok  	github.com/dsrvlabs/vatz/manager/executor	0.452s	coverage: 68.9% of statements
ok  	github.com/dsrvlabs/vatz/manager/healthcheck	0.566s	coverage: 46.5% of statements
ok  	github.com/dsrvlabs/vatz/manager/plugin	5.356s	coverage: 50.6% of statements
?   	github.com/dsrvlabs/vatz/manager/types	[no test files]
?   	github.com/dsrvlabs/vatz/mocks	[no test files]
ok  	github.com/dsrvlabs/vatz/monitoring/prometheus	0.322s	coverage: 0.0% of statements
ok  	github.com/dsrvlabs/vatz/rpc	1.786s	coverage: 67.2% of statements
ok  	github.com/dsrvlabs/vatz/utils	0.886s	coverage: 7.1% of statements
```