### PR TITLE
fix panic message when all CLI commands fails.

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 	"time"
 
 	"github.com/dsrvlabs/vatz/cmd"
@@ -17,6 +18,12 @@ func main() {
 	rootCmd := cmd.CreateRootCommand()
 
 	if err := rootCmd.Execute(); err != nil {
-		panic(err)
+		if strings.Contains(err.Error(), "open default.yaml") {
+			msg := "Please, Check config file default.yaml path or initialize VATZ with command `vatz init` to create config file `default.yaml`."
+			log.Error().Str("module", "config").Msg(msg)
+		} else {
+			log.Error().Msgf("VATZ CLI command Error: %s", err)
+		}
+		//panic(err)
 	}
 }


### PR DESCRIPTION
### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Enhancement
- [x] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

**Related:** # (issue)
realted: #469 

**Summary**
as issue 
- #469, pretty much every CLI commands panics when there's error. 
so it hide those panic messages 

---

### 3. Comments
> Please, leave a comments if there's further action that requires. 
```
 dongyookang DK 🔑   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-469
 make coverage
fatal: No names found, cannot describe anything.
?       github.com/dsrvlabs/vatz        [no test files]
?       github.com/dsrvlabs/vatz/manager/types  [no test files]
?       github.com/dsrvlabs/vatz/mocks  [no test files]
ok      github.com/dsrvlabs/vatz/cmd    14.427s coverage: 23.5% of statements
ok      github.com/dsrvlabs/vatz/manager/api    0.499s  coverage: 0.0% of statements [no tests to run]
ok      github.com/dsrvlabs/vatz/manager/config 0.811s  coverage: 77.8% of statements
ok      github.com/dsrvlabs/vatz/manager/dispatcher     1.602s  coverage: 7.1% of statements
ok      github.com/dsrvlabs/vatz/manager/executor       1.755s  coverage: 68.9% of statements
ok      github.com/dsrvlabs/vatz/manager/healthcheck    1.449s  coverage: 46.5% of statements
ok      github.com/dsrvlabs/vatz/manager/plugin 19.831s coverage: 51.1% of statements
ok      github.com/dsrvlabs/vatz/monitoring/prometheus  1.127s  coverage: 0.0% of statements
ok      github.com/dsrvlabs/vatz/rpc    2.299s  coverage: 67.2% of statements
ok      github.com/dsrvlabs/vatz/utils  0.950s  coverage: 7.1% of statements
 dongyookang DK 🔑   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-469
 

```