### PR TITLE
Divide Logs by its level Debug, Info, trace. 

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,12 +1,11 @@
 package cmd
 
 import (
-	tp "github.com/dsrvlabs/vatz/manager/types"
-	"github.com/spf13/cobra"
-
 	dp "github.com/dsrvlabs/vatz/manager/dispatcher"
 	ex "github.com/dsrvlabs/vatz/manager/executor"
 	health "github.com/dsrvlabs/vatz/manager/healthcheck"
+	tp "github.com/dsrvlabs/vatz/manager/types"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -33,6 +32,8 @@ var (
 // CreateRootCommand creates root command of Cobra.
 func CreateRootCommand() *cobra.Command {
 	rootCmd := &cobra.Command{}
+	rootCmd.PersistentFlags().BoolP("debug", "d", true, "Set Log level to Debug.")
+
 	rootCmd.AddCommand(createInitCommand(tp.LIVE))
 	rootCmd.AddCommand(createStartCommand())
 	rootCmd.AddCommand(createPluginCommand())

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,6 +5,8 @@ import (
 	ex "github.com/dsrvlabs/vatz/manager/executor"
 	health "github.com/dsrvlabs/vatz/manager/healthcheck"
 	tp "github.com/dsrvlabs/vatz/manager/types"
+	"github.com/dsrvlabs/vatz/utils"
+	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 )
 
@@ -22,22 +24,34 @@ var (
 	dispatchers            []dp.Dispatcher
 	defaultVerifyInterval  = 15
 	defaultExecuteInterval = 30
-
-	configFile string
-	logfile    string
-	vatzRPC    string
-	promPort   string
+	IsDebugLevel           bool
+	IsTraceLevel           bool
+	configFile             string
+	logfile                string
+	vatzRPC                string
+	promPort               string
 )
 
-// CreateRootCommand creates root command of Cobra.
-func CreateRootCommand() *cobra.Command {
-	rootCmd := &cobra.Command{}
-	rootCmd.PersistentFlags().BoolP("debug", "d", true, "Set Log level to Debug.")
-
+/*	GetRootCommand: Return Cobra Root command include all subcommands .*/
+func GetRootCommand() *cobra.Command {
+	rootCmd := CreateRootCommand()
 	rootCmd.AddCommand(createInitCommand(tp.LIVE))
 	rootCmd.AddCommand(createStartCommand())
 	rootCmd.AddCommand(createPluginCommand())
 	rootCmd.AddCommand(createVersionCommand())
+	return rootCmd
+}
 
+/*	CreateRootCommand: Create Root command which initialize root command and global flags. */
+func CreateRootCommand() *cobra.Command {
+	rootCmd := &cobra.Command{PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if IsDebugLevel {
+			utils.SetGlobalLogLevel(zerolog.DebugLevel)
+		} else if IsTraceLevel {
+			utils.SetGlobalLogLevel(zerolog.TraceLevel)
+		}
+	}}
+	rootCmd.PersistentFlags().BoolVarP(&IsDebugLevel, "debug", "", false, "Enable debug mode on Log.")
+	rootCmd.PersistentFlags().BoolVarP(&IsTraceLevel, "trace", "", false, "Enable Trace mode on Log.")
 	return rootCmd
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -17,7 +17,7 @@ func createInitCommand(initializer tp.Initializer) *cobra.Command {
 		Use:   "init",
 		Short: "init",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			log.Info().Str("module", "main").Msg("init")
+			log.Debug().Str("module", "main").Msg("init")
 
 			template := `vatz_protocol_info:
   home_path: "%s"
@@ -130,8 +130,8 @@ func createInitCommand(initializer tp.Initializer) *cobra.Command {
 			}
 
 			template = fmt.Sprintf(template, homePath)
-			log.Info().Str("module", "main").Msgf("home path %s", homePath)
-			log.Info().Str("module", "main").Msgf("create file %s", filename)
+			log.Debug().Str("module", "main").Msgf("home path %s", homePath)
+			log.Debug().Str("module", "main").Msgf("create file %s", filename)
 
 			f, err := os.Create(filename)
 			if err != nil {
@@ -159,7 +159,7 @@ func createInitCommand(initializer tp.Initializer) *cobra.Command {
 				return err
 			}
 
-			log.Info().Str("module", "main").Msgf("Plugin dir %s", pluginDir)
+			log.Debug().Str("module", "main").Msgf("Plugin dir %s", pluginDir)
 			mgr := plugin.NewManager(pluginDir)
 			return mgr.Init(initializer)
 		},

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -245,7 +245,9 @@ var (
 			}
 
 			log.Info().Str("module", "plugin").Msgf("List plugins")
-
+			log.Debug().Str("test", "test").Msg("This is a test")
+			log.Error().Str("test", "test").Msg("This is a test")
+			log.Warn().Str("test", "test").Msg("This is a test")
 			mgr := plugin.NewManager(pluginDir)
 			plugins, err := mgr.List()
 			if err != nil {

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -37,7 +37,8 @@ var (
 			return err
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/v1/plugin_status", vatzRPC), nil)
+			statusRequest := fmt.Sprintf("%s/v1/plugin_status", vatzRPC)
+			req, err := http.NewRequest(http.MethodGet, statusRequest, nil)
 			if err != nil {
 				return err
 			}
@@ -48,6 +49,8 @@ var (
 				log.Error().Str("module", "plugin").Err(err)
 				return err
 			}
+
+			log.Debug().Str("module", "plugin").Msgf("Plugin(s) status is requested to  %s.", statusRequest)
 
 			respData, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -69,7 +72,7 @@ var (
 				return err
 			}
 
-			fmt.Println("***** Plugin status *****")
+			fmt.Println("***** Plugin Status *****")
 			for i, plugin := range statusResp.PluginStatus {
 				fmt.Printf("%d: %s [%s]\n", i+1, plugin.PluginName, plugin.Status)
 			}
@@ -94,20 +97,22 @@ var (
 				return err
 			}
 
-			log.Info().Str("module", "plugin").Msgf("Install new plugin %s at %s.", args[0], pluginDir)
+			log.Debug().Str("module", "plugin").Msgf("Install new plugin %s at %s.", args[0], pluginDir)
 
 			pluginVersion := defaultVersion
 			if viper.GetString("plugin_version") != "" {
 				pluginVersion = viper.GetString("plugin_version")
 			}
 
-			log.Info().Str("module", "plugin").Msgf("Installing plugin version is %s.", pluginVersion)
+			log.Debug().Str("module", "plugin").Msgf("Installing plugin version is %s.", pluginVersion)
 			mgr := plugin.NewManager(pluginDir)
 			err = mgr.Install(args[0], args[1], pluginVersion)
 			if err != nil {
 				log.Error().Str("module", "plugin").Err(err)
 				return err
 			}
+
+			log.Info().Str("module", "plugin").Msgf("A new plugin %s is successfully installed.", args[1])
 			return nil
 		},
 	}
@@ -127,7 +132,7 @@ var (
 				return err
 			}
 
-			log.Info().Str("module", "plugin").Msgf("Uninstall a plugin %s from %s", args[0], pluginDir)
+			log.Debug().Str("module", "plugin").Msgf("Uninstall a plugin %s from %s", args[0], pluginDir)
 
 			// TODO: Handle already installed.
 			// TODO: Handle invalid repo name.
@@ -137,6 +142,7 @@ var (
 				log.Error().Str("module", "plugin").Err(err)
 				return err
 			}
+			log.Info().Str("module", "plugin").Msgf("Plugin %s is successfully uninstalled from %s", args[0], pluginDir)
 			return nil
 		},
 	}
@@ -171,7 +177,7 @@ var (
 				return err
 			}
 
-			log.Info().Str("module", "plugin").Msgf("Plugin log redirect to %s", logfile)
+			log.Debug().Str("module", "plugin").Msgf("Plugin log redirect to %s", logfile)
 
 			mgr := plugin.NewManager(pluginDir)
 			return mgr.Start(pluginName, exeArgs, f)
@@ -215,7 +221,7 @@ var (
 				return err
 			}
 
-			log.Info().Str("module", "plugin").Msgf("enable installed plugin %s at %s", args[0], pluginDir)
+			log.Debug().Str("module", "plugin").Msgf("enable installed plugin %s at %s", args[0], pluginDir)
 
 			// TODO: Handle already installed.
 			// TODO: Handle invalid repo name.

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -243,11 +243,7 @@ var (
 			if err != nil {
 				return err
 			}
-
-			log.Info().Str("module", "plugin").Msgf("List plugins")
-			log.Debug().Str("test", "test").Msg("This is a test")
-			log.Error().Str("test", "test").Msg("This is a test")
-			log.Warn().Str("test", "test").Msg("This is a test")
+			log.Debug().Str("module", "plugin").Msgf("List plugins")
 			mgr := plugin.NewManager(pluginDir)
 			plugins, err := mgr.List()
 			if err != nil {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -28,17 +28,17 @@ import (
 )
 
 func createStartCommand() *cobra.Command {
+	log.Debug().Str("module", "cmd > start").Msg("start command")
 	cmd := &cobra.Command{
 		Use:   "start",
 		Short: "start VATZ",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			log.Debug().Str("module", "cmd start").Msgf("Set logfile %s", logfile)
 			return utils.SetLog(logfile, defaultFlagLog)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			log.Info().Str("module", "main").Msg("start")
-			log.Info().Str("module", "main").Msgf("load config %s", configFile)
-			log.Info().Str("module", "main").Msgf("logfile %s", logfile)
 
+			log.Debug().Str("module", "main").Msgf("load config %s", configFile)
 			_, err := config.InitConfig(configFile)
 			if err != nil {
 				log.Error().Str("module", "config").Msgf("loadConfig Error: %s", err)
@@ -62,7 +62,7 @@ func createStartCommand() *cobra.Command {
 }
 
 func initiateServer(ch <-chan os.Signal) error {
-	log.Info().Str("module", "main").Msgf("Initialize Servers: %s", "VATZ Manager")
+	log.Info().Str("module", "main").Msg("Initialize Server")
 	_, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -78,15 +78,15 @@ func initiateServer(ch <-chan os.Signal) error {
 	addr := fmt.Sprintf(":%d", vatzConfig.Port)
 	err := healthChecker.VATZHealthCheck(vatzConfig.HealthCheckerSchedule, dispatchers)
 	if err != nil {
-		log.Error().Str("module", "main").Msgf("VATZHealthCheck Error: %s", err)
+		log.Error().Str("module", "cmd > start").Msgf("VATZHealthCheck Error: %s", err)
 	}
 
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
-		log.Error().Str("module", "main").Msgf("VATZ Listener Error: %s", err)
+		log.Error().Str("module", "cmd > start").Msgf("VATZ Listener Error: %s", err)
 	}
 
-	log.Info().Str("module", "main").Msgf("VATZ Listening Port: %s", addr)
+	log.Info().Str("module", "main").Msgf("Start VATZ Server on Listening Port: %s", addr)
 	startExecutor(cfg.PluginInfos, ch)
 
 	rpcServ := rpc.NewRPCService()
@@ -153,11 +153,11 @@ func multiPluginExecutor(plugin config.Plugin, singleClient pluginPb.PluginClien
 			if pluginState.IsEnabled {
 				if okToSend == true {
 					if pluginStateErr != nil {
-						log.Error().Str("module", "main").Msgf("Executor Error: %s", pluginStateErr)
+						log.Error().Str("module", "cmd > start").Msgf("Executor Error: %s", pluginStateErr)
 					}
 					err := executor.Execute(ctx, singleClient, plugin, dispatchers)
 					if err != nil {
-						log.Error().Str("module", "main").Msgf("Executor Error: %s", err)
+						log.Error().Str("module", "cmd > start").Msgf("Executor Error: %s", err)
 					}
 				}
 			}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -19,7 +19,6 @@ import (
 	"github.com/dsrvlabs/vatz/monitoring/prometheus"
 	"github.com/dsrvlabs/vatz/rpc"
 	"github.com/dsrvlabs/vatz/utils"
-	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -33,17 +32,7 @@ func createStartCommand() *cobra.Command {
 		Use:   "start",
 		Short: "start VATZ",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if logfile == defaultFlagLog {
-				log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339})
-			} else {
-				f, err := os.OpenFile(logfile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
-				if err != nil {
-					return err
-				}
-
-				log.Logger = log.Output(zerolog.ConsoleWriter{Out: f, TimeFormat: time.RFC3339})
-			}
-			return nil
+			return utils.SetLog(logfile, defaultFlagLog)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Info().Str("module", "main").Msg("start")

--- a/main.go
+++ b/main.go
@@ -1,37 +1,22 @@
 package main
 
 import (
-	"flag"
 	"github.com/dsrvlabs/vatz/cmd"
 	"github.com/dsrvlabs/vatz/utils"
-	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
 	"strings"
 )
 
-const defaultLogLevel = zerolog.InfoLevel
-
-var logLevel zerolog.Level
+var rootCmd *cobra.Command
 
 func init() {
-	debugPtr := flag.Bool("debug", false, "Enable debug mode")
-
-	// Parse the command-line flags
-	flag.Parse()
-
-	// If the "debug" flag is set to true, set the log level to DebugLevel
-	if *debugPtr {
-		utils.SetGlobalLogLevel(zerolog.DebugLevel)
-	} else {
-		utils.SetGlobalLogLevel(defaultLogLevel)
-	}
-
-	log.Logger = log.Output(utils.GetConsoleWriter())
+	//Set to Log level to Info which reduce log that doesn't be recorded and save log volumes.
+	utils.InitializeLogger()
+	rootCmd = cmd.GetRootCommand()
 }
 
 func main() {
-	rootCmd := cmd.CreateRootCommand()
-
 	if err := rootCmd.Execute(); err != nil {
 		if strings.Contains(err.Error(), "open default.yaml") {
 			msg := "Please, Check config file default.yaml path or initialize VATZ with command `vatz init` to create config file `default.yaml`."
@@ -39,7 +24,5 @@ func main() {
 		} else {
 			log.Error().Msgf("VATZ CLI command Error: %s", err)
 		}
-		//panic(err)
 	}
-
 }

--- a/main.go
+++ b/main.go
@@ -1,17 +1,32 @@
 package main
 
 import (
-	"os"
-	"strings"
-	"time"
-
+	"flag"
 	"github.com/dsrvlabs/vatz/cmd"
+	"github.com/dsrvlabs/vatz/utils"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"strings"
 )
 
+const defaultLogLevel = zerolog.InfoLevel
+
+var logLevel zerolog.Level
+
 func init() {
-	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339})
+	debugPtr := flag.Bool("debug", false, "Enable debug mode")
+
+	// Parse the command-line flags
+	flag.Parse()
+
+	// If the "debug" flag is set to true, set the log level to DebugLevel
+	if *debugPtr {
+		utils.SetGlobalLogLevel(zerolog.DebugLevel)
+	} else {
+		utils.SetGlobalLogLevel(defaultLogLevel)
+	}
+
+	log.Logger = log.Output(utils.GetConsoleWriter())
 }
 
 func main() {
@@ -26,4 +41,5 @@ func main() {
 		}
 		//panic(err)
 	}
+
 }

--- a/manager/config/config.go
+++ b/manager/config/config.go
@@ -225,7 +225,7 @@ func InitConfig(configFile string) (*Config, error) {
 
 	configOnce.Do(func() {
 		// TODO: How do I add default values?
-		log.Info().Str("module", "config").Msgf("Load Config %s", configFile)
+		log.Debug().Str("module", "config").Msgf("Load Config %s", configFile)
 
 		defer wg.Done()
 		var configData []byte

--- a/manager/plugin/db.go
+++ b/manager/plugin/db.go
@@ -231,7 +231,7 @@ func (p *pluginDB) UpdatePluginEnabling(name string, isEnabled bool) error {
 }
 
 func (p *pluginDB) List() ([]pluginEntry, error) {
-	log.Info().Str("module", "db").Msg("List")
+	log.Debug().Str("module", "db").Msg("List")
 
 	q := `SELECT name, is_enabled, repository, binary_location, version, installed_at FROM plugin`
 	rows, err := p.conn.QueryContext(p.ctx, q)
@@ -278,7 +278,7 @@ func newWriter(dbfile string) (dbWriter, error) {
 	chanErr := make(chan error, 1)
 
 	once.Do(func() {
-		log.Info().Str("module", "db").Msg("Create DB Instance")
+		log.Debug().Str("module", "db").Msg("Create DB Instance")
 
 		ctx := context.Background()
 		conn, err := getDBConnection(ctx, dbfile)

--- a/manager/plugin/db.go
+++ b/manager/plugin/db.go
@@ -109,7 +109,7 @@ func (p *pluginDB) MigratePluginTable() error {
 }
 
 func (p *pluginDB) AddPlugin(e pluginEntry) error {
-	log.Info().Str("module", "db").Msg("AddPlugin")
+	log.Debug().Str("module", "db").Msg("AddPlugin")
 
 	opts := &sql.TxOptions{
 		Isolation: sql.LevelDefault,
@@ -168,7 +168,7 @@ CREATE TABLE IF NOT EXISTS plugin (
 }
 
 func (p *pluginDB) DeletePlugin(name string) error {
-	log.Info().Str("module", "db").Msg("DeletePlugin")
+	log.Debug().Str("module", "db").Msgf("Uninstall Plugin %s", name)
 
 	opts := &sql.TxOptions{Isolation: sql.LevelDefault}
 	tx, err := p.conn.BeginTx(p.ctx, opts)
@@ -193,7 +193,7 @@ func (p *pluginDB) DeletePlugin(name string) error {
 
 func (p *pluginDB) UpdatePluginEnabling(name string, isEnabled bool) error {
 	// TODO: 1. Set best identifier for plugins either of Plugin_id or Name
-	log.Info().Str("module", "db").Msg("UpdatePlugin")
+	log.Debug().Str("module", "db").Msg("UpdatePlugin")
 
 	response := "disabled"
 	if isEnabled {
@@ -225,7 +225,7 @@ func (p *pluginDB) UpdatePluginEnabling(name string, isEnabled bool) error {
 		return err
 	}
 
-	log.Info().Str("module", "db").Msgf("Plugin %s has been updated: %s.", name, response)
+	log.Info().Str("module", "db").Msgf("Plugin %s is %s.", name, response)
 
 	return nil
 }
@@ -257,7 +257,7 @@ func (p *pluginDB) List() ([]pluginEntry, error) {
 }
 
 func (p *pluginDB) Get(name string) (*pluginEntry, error) {
-	log.Info().Str("module", "db").Msgf("Get %s", name)
+	log.Debug().Str("module", "db").Msgf("Get %s", name)
 
 	q := `SELECT name, is_enabled, repository, binary_location, version, installed_at FROM plugin WHERE name=?`
 	e := pluginEntry{}
@@ -345,7 +345,7 @@ func getDBConnection(ctx context.Context, dbfile string) (*sql.Conn, error) {
 }
 
 func initDB(dbfile string) error {
-	log.Info().Str("module", "db").Msgf("initDB %s", dbfile)
+	log.Info().Str("module", "db").Msgf("Initialize DB %s", dbfile)
 
 	if db != nil {
 		db.conn.Close()
@@ -354,7 +354,7 @@ func initDB(dbfile string) error {
 		once = sync.Once{}
 	}
 
-	log.Info().Str("module", "db").Msg("Remove old DB file")
+	log.Debug().Str("module", "db").Msg("Remove old DB file")
 
 	err := os.Remove(dbfile)
 	if err != nil && !os.IsNotExist(err) {
@@ -367,7 +367,7 @@ func initDB(dbfile string) error {
 		_ = os.Mkdir(path, 0755)
 	}
 
-	log.Info().Str("module", "db").Msg("Create new DB file")
+	log.Debug().Str("module", "db").Msg("Create new DB file")
 
 	f, err := os.Create(dbfile)
 	if err != nil {

--- a/manager/plugin/plugin.go
+++ b/manager/plugin/plugin.go
@@ -72,7 +72,7 @@ func (m *vatzPluginManager) Install(repo, name, version string) error {
 		fixedRepo = strTokens[0]
 	}
 
-	log.Info().Str("module", "plugin").Msgf("Install new plugin %s", fixedRepo)
+	log.Debug().Str("module", "plugin").Msgf("Install new plugin %s", fixedRepo)
 
 	var stdout, stderr bytes.Buffer
 
@@ -121,6 +121,7 @@ func (m *vatzPluginManager) Install(repo, name, version string) error {
 		return err
 	}
 
+	log.Debug().Str("module", "plugin").Msgf("A new plugin %s from %s is installed at %s.", name, repo, newPath)
 	return nil
 }
 
@@ -158,7 +159,7 @@ func (m *vatzPluginManager) List() ([]VatzPlugin, error) {
 }
 
 func (m *vatzPluginManager) Uninstall(name string) error {
-	log.Info().Str("module", "plugin").Msgf("List")
+	log.Debug().Str("module", "plugin").Msgf("Uninstall")
 	ps, err := m.findProcessByName(name)
 	if err != nil {
 		if !strings.Contains(err.Error(), "can't find the process") {
@@ -211,7 +212,7 @@ func (m *vatzPluginManager) Uninstall(name string) error {
 }
 
 func (m *vatzPluginManager) Get(name string) (VatzPlugin, error) {
-	log.Info().Str("module", "plugin").Msgf("Get %s", name)
+	log.Debug().Str("module", "plugin").Msgf("Get %s", name)
 
 	dbRd, err := newReader(fmt.Sprintf("%s/%s", m.home, pluginDBName))
 	if err != nil {
@@ -256,7 +257,7 @@ func (m *vatzPluginManager) Update(pluginID string, isEnabled bool) error {
 }
 
 func (m *vatzPluginManager) Start(name, args string, logfile *os.File) error {
-	log.Info().Str("module", "plugin").Msgf("Start plugin %s", name)
+	log.Debug().Str("module", "plugin").Msgf("Start plugin %s", name)
 
 	dbRd, err := newReader(fmt.Sprintf("%s/%s", m.home, pluginDBName))
 	if err != nil {
@@ -275,12 +276,12 @@ func (m *vatzPluginManager) Start(name, args string, logfile *os.File) error {
 	splits := strings.FieldsFunc(args, f)
 	cmd := exec.Command(e.BinaryLocation, splits...)
 	cmd.Stdout = logfile
-
+	log.Info().Str("module", "plugin").Msgf("Plugin %s is successfully started.", name)
 	return cmd.Start()
 }
 
 func (m *vatzPluginManager) Stop(name string) error {
-	log.Info().Str("module", "plugin").Msgf("Stop plugin %s", name)
+	log.Debug().Str("module", "plugin").Msgf("Stop plugin %s", name)
 
 	ps, err := m.findProcessByName(name)
 	if err != nil {
@@ -292,12 +293,12 @@ func (m *vatzPluginManager) Stop(name string) error {
 		log.Error().Str("module", "plugin").Msgf("Stop > ps.Kill Error: %s", err)
 		return err
 	}
-
+	log.Info().Str("module", "plugin").Msgf("Plugin %s is successfully stopped.", name)
 	return nil
 }
 
 func (m *vatzPluginManager) findProcessByName(name string) (*process.Process, error) {
-	log.Info().Str("module", "plugin").Msgf("Find Process %s", name)
+	log.Debug().Str("module", "plugin").Msgf("Find Process %s", name)
 
 	processes, err := process.Processes()
 	if err != nil {

--- a/manager/plugin/plugin.go
+++ b/manager/plugin/plugin.go
@@ -125,7 +125,7 @@ func (m *vatzPluginManager) Install(repo, name, version string) error {
 }
 
 func (m *vatzPluginManager) List() ([]VatzPlugin, error) {
-	log.Info().Str("module", "plugin").Msgf("List")
+	log.Debug().Str("module", "plugin").Msgf("List")
 
 	dbRd, err := newReader(fmt.Sprintf("%s/%s", m.home, pluginDBName))
 	if err != nil {

--- a/utils/logs.go
+++ b/utils/logs.go
@@ -7,23 +7,27 @@ import (
 	"time"
 )
 
-func GetConsoleWriter() zerolog.ConsoleWriter {
-	return zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
+var (
+	cmdConsoleWriter = zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
+)
+
+func InitializeLogger() {
+	SetGlobalLogLevel(zerolog.InfoLevel)
+	log.Logger = log.Output(cmdConsoleWriter)
 }
 
 func SetGlobalLogLevel(level zerolog.Level) {
 	/*
 			zerolog allows for logging at the following levels (from highest to lowest):
-			panic (zerolog.PanicLevel, 5)
-			fatal (zerolog.FatalLevel, 4)
-			error (zerolog.ErrorLevel, 3)
-			warn (zerolog.WarnLevel, 2)
-			info (zerolog.InfoLevel, 1)
-			debug (zerolog.DebugLevel, 0)
-			trace (zerolog.TraceLevel, -1)
-
-		VATZ's global loglevel is Info, which hide debug and trace
-		and ignores all other cases except Info, Debug, and Trace
+					panic (zerolog.PanicLevel, 5)
+					fatal (zerolog.FatalLevel, 4)
+					error (zerolog.ErrorLevel, 3)
+					warn (zerolog.WarnLevel, 2)
+					info (zerolog.InfoLevel, 1)
+					debug (zerolog.DebugLevel, 0)
+					trace (zerolog.TraceLevel, -1)
+			VATZ's global loglevel is Info, which hide debug and trace and ignores all other cases except
+		    Info, Debug, and Trace.
 	*/
 	switch {
 	case level == zerolog.DebugLevel:
@@ -37,13 +41,12 @@ func SetGlobalLogLevel(level zerolog.Level) {
 
 func SetLog(logfile string, defaultFlagLog string) error {
 	if logfile == defaultFlagLog {
-		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339})
+		log.Logger = log.Output(cmdConsoleWriter)
 	} else {
 		f, err := os.OpenFile(logfile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
 		if err != nil {
 			return err
 		}
-
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: f, TimeFormat: time.RFC3339})
 	}
 	return nil

--- a/utils/logs.go
+++ b/utils/logs.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"os"
+	"time"
+)
+
+func GetConsoleWriter() zerolog.ConsoleWriter {
+	return zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
+}
+
+func SetGlobalLogLevel(level zerolog.Level) {
+	/*
+			zerolog allows for logging at the following levels (from highest to lowest):
+			panic (zerolog.PanicLevel, 5)
+			fatal (zerolog.FatalLevel, 4)
+			error (zerolog.ErrorLevel, 3)
+			warn (zerolog.WarnLevel, 2)
+			info (zerolog.InfoLevel, 1)
+			debug (zerolog.DebugLevel, 0)
+			trace (zerolog.TraceLevel, -1)
+
+		VATZ's global loglevel is Info, which hide debug and trace
+		and ignores all other cases except Info, Debug, and Trace
+	*/
+	switch {
+	case level == zerolog.DebugLevel:
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	case level == zerolog.TraceLevel:
+		zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	default:
+		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	}
+}
+
+func SetLog(logfile string, defaultFlagLog string) error {
+	if logfile == defaultFlagLog {
+		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339})
+	} else {
+		f, err := os.OpenFile(logfile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+		if err != nil {
+			return err
+		}
+
+		log.Logger = log.Output(zerolog.ConsoleWriter{Out: f, TimeFormat: time.RFC3339})
+	}
+	return nil
+}


### PR DESCRIPTION
### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Enhancement
- [ ] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

close: #485 

**Summary**

As explained,  on #485
-  [Case 1](https://github.com/dsrvlabs/vatz/issues/485#issuecomment-1661065595), `Info` level logs are recorded on the logs as default unless user enable debug mode with flag `debug` which's showing all traceable `debug` logs. 
- [Case 2](https://github.com/dsrvlabs/vatz/issues/485#issuecomment-1661065785),  running Vatz doesn't clear show its even drives per its log level including `Info` `debug`, and `trace` 
---

### 3. Comments
> Please, leave a comments if there's further action that requires. 

```
 dongyookang DK 🐵   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-485
 make coverage
?       github.com/dsrvlabs/vatz        [no test files]
?       github.com/dsrvlabs/vatz/manager/types  [no test files]
?       github.com/dsrvlabs/vatz/mocks  [no test files]
ok      github.com/dsrvlabs/vatz/cmd    2.779s  coverage: 23.6% of statements
ok      github.com/dsrvlabs/vatz/manager/api    0.517s  coverage: 0.0% of statements [no tests to run]
ok      github.com/dsrvlabs/vatz/manager/config 0.644s  coverage: 77.8% of statements
ok      github.com/dsrvlabs/vatz/manager/dispatcher     1.386s  coverage: 7.1% of statements
ok      github.com/dsrvlabs/vatz/manager/executor       1.253s  coverage: 68.9% of statements
ok      github.com/dsrvlabs/vatz/manager/healthcheck    0.401s  coverage: 46.5% of statements
ok      github.com/dsrvlabs/vatz/manager/plugin 7.409s  coverage: 51.0% of statements
ok      github.com/dsrvlabs/vatz/monitoring/prometheus  1.541s  coverage: 0.0% of statements
ok      github.com/dsrvlabs/vatz/rpc    1.791s  coverage: 67.2% of statements
ok      github.com/dsrvlabs/vatz/utils  0.973s  coverage: 4.9% of statements
 dongyookang DK 🐵   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-485

```