### PR TITLE
Add log client connected to plugin successfully.

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -11,7 +11,6 @@ import (
 
 	managerPb "github.com/dsrvlabs/vatz-proto/manager/v1"
 	pluginPb "github.com/dsrvlabs/vatz-proto/plugin/v1"
-	pluginpb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	"github.com/dsrvlabs/vatz/manager/api"
 	config "github.com/dsrvlabs/vatz/manager/config"
 	dp "github.com/dsrvlabs/vatz/manager/dispatcher"
@@ -117,7 +116,7 @@ func initiateServer(ch <-chan os.Signal) error {
 	return nil
 }
 
-func startExecutor(grpcClients []pluginpb.PluginClient, pluginInfo config.PluginInfo, quit <-chan os.Signal) {
+func startExecutor(grpcClients []pluginPb.PluginClient, pluginInfo config.PluginInfo, quit <-chan os.Signal) {
 	// TODO:: value in map would be overridden by different plugins flag value if function name is the same
 	isOkayToSend := false
 	if len(grpcClients) == 0 {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -102,7 +102,7 @@ func initiateServer(ch <-chan os.Signal) error {
 		} else {
 			prometheusPort = promPort
 		}
-		prometheus.InitPrometheusServer(monitoringInfo.Prometheus.Address, prometheusPort, cfg.Vatz.ProtocolIdentifier, grpcClients)
+		prometheus.InitPrometheusServer(monitoringInfo.Prometheus.Address, prometheusPort, cfg.Vatz.ProtocolIdentifier)
 	}
 
 	log.Info().Str("module", "main").Msg("VATZ Manager Started")

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -113,15 +113,15 @@ func initiateServer(ch <-chan os.Signal) error {
 	return nil
 }
 
-func startExecutor(grpcClients []pluginPb.PluginClient, pluginInfo config.PluginInfo, quit <-chan os.Signal) {
+func startExecutor(grpcClients []utils.GClientWithPlugin, pluginInfo config.PluginInfo, quit <-chan os.Signal) {
 	// TODO:: value in map would be overridden by different plugins flag value if function name is the same
 	isOkayToSend := false
 	if len(grpcClients) == 0 {
 		log.Error().Str("module", "cmd:Start").Msg("No Plugins are set, Check your Configs.")
 		os.Exit(1)
 	}
-	for idx, singleClient := range grpcClients {
-		go multiPluginExecutor(pluginInfo.Plugins[idx], singleClient, isOkayToSend, quit)
+	for _, client := range grpcClients {
+		go multiPluginExecutor(client.PluginInfo, client.GRPCClient, isOkayToSend, quit)
 	}
 }
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -119,7 +119,11 @@ func startExecutor(pluginInfo config.PluginInfo, quit <-chan os.Signal) {
 	// TODO:: value in map would be overridden by different plugins flag value if function name is the same
 	isOkayToSend := false
 	grpcClients := utils.GetClients(pluginInfo.Plugins)
-	// TODO: Need updated with better way for Dynamic handlers
+
+	if len(grpcClients) == 0 {
+		log.Error().Str("module", "cmd:Start").Msg("No Plugins are set, Check your Configs.")
+		os.Exit(1)
+	}
 	for idx, singleClient := range grpcClients {
 		go multiPluginExecutor(pluginInfo.Plugins[idx], singleClient, isOkayToSend, quit)
 	}

--- a/monitoring/prometheus/metric.go
+++ b/monitoring/prometheus/metric.go
@@ -7,9 +7,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-func (c *prometheusManager) getPluginUp(plugins []config.Plugin, hostName string) (
-	pluginUp map[int]*prometheusValue,
-) {
+func (c *prometheusManager) getPluginUp(plugins []config.Plugin, hostName string) (pluginUp map[int]*prometheusValue) {
 	gClients := utils.GetClients(plugins)
 	pluginUp = make(map[int]*prometheusValue)
 

--- a/monitoring/prometheus/metric.go
+++ b/monitoring/prometheus/metric.go
@@ -2,20 +2,21 @@ package prometheus
 
 import (
 	"context"
-	pluginpb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	"github.com/dsrvlabs/vatz/manager/config"
+	"github.com/dsrvlabs/vatz/utils"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-func (c *prometheusManager) getPluginUp(plugins []config.Plugin, hostName string, grpcClients []pluginpb.PluginClient) (pluginUp map[int]*prometheusValue) {
+func (c *prometheusManager) getPluginUp(plugins []config.Plugin, hostName string) (pluginUp map[int]*prometheusValue) {
 	pluginUp = make(map[int]*prometheusValue)
+	gClients := utils.GetClients(plugins)
 	for idx, plugin := range plugins {
 		pluginUp[plugin.Port] = &prometheusValue{
 			Up:         1,
 			PluginName: plugin.Name,
 			HostName:   hostName,
 		}
-		verify, err := grpcClients[idx].Verify(context.Background(), new(emptypb.Empty))
+		verify, err := gClients[idx].Verify(context.Background(), new(emptypb.Empty))
 		if err != nil || verify == nil {
 			pluginUp[plugin.Port].Up = 0
 		}

--- a/monitoring/prometheus/metric.go
+++ b/monitoring/prometheus/metric.go
@@ -2,23 +2,24 @@ package prometheus
 
 import (
 	"context"
-	"github.com/dsrvlabs/vatz/manager/config"
 	"github.com/dsrvlabs/vatz/utils"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-func (c *prometheusManager) getPluginUp(plugins []config.Plugin, hostName string) (pluginUp map[int]*prometheusValue) {
+func (c *prometheusManager) getPluginUp(hostName string, grpcClientAndPluginInfo []utils.GClientWithPlugin) (pluginUp map[int]*prometheusValue) {
 	pluginUp = make(map[int]*prometheusValue)
-	gClients := utils.GetClients(plugins)
-	for idx, plugin := range plugins {
-		pluginUp[plugin.Port] = &prometheusValue{
+
+	for _, info := range grpcClientAndPluginInfo {
+		pluginInfo := info.PluginInfo
+		pluginUp[pluginInfo.Port] = &prometheusValue{
 			Up:         1,
-			PluginName: plugin.Name,
+			PluginName: pluginInfo.Name,
 			HostName:   hostName,
 		}
-		verify, err := gClients[idx].Verify(context.Background(), new(emptypb.Empty))
+		grpcClient := info.GRPCClient
+		verify, err := grpcClient.Verify(context.Background(), new(emptypb.Empty))
 		if err != nil || verify == nil {
-			pluginUp[plugin.Port].Up = 0
+			pluginUp[pluginInfo.Port].Up = 0
 		}
 	}
 

--- a/monitoring/prometheus/metric.go
+++ b/monitoring/prometheus/metric.go
@@ -2,22 +2,20 @@ package prometheus
 
 import (
 	"context"
+	pluginpb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	"github.com/dsrvlabs/vatz/manager/config"
-	"github.com/dsrvlabs/vatz/utils"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-func (c *prometheusManager) getPluginUp(plugins []config.Plugin, hostName string) (pluginUp map[int]*prometheusValue) {
-	gClients := utils.GetClients(plugins)
+func (c *prometheusManager) getPluginUp(plugins []config.Plugin, hostName string, grpcClients []pluginpb.PluginClient) (pluginUp map[int]*prometheusValue) {
 	pluginUp = make(map[int]*prometheusValue)
-
 	for idx, plugin := range plugins {
 		pluginUp[plugin.Port] = &prometheusValue{
 			Up:         1,
 			PluginName: plugin.Name,
 			HostName:   hostName,
 		}
-		verify, err := gClients[idx].Verify(context.Background(), new(emptypb.Empty))
+		verify, err := grpcClients[idx].Verify(context.Background(), new(emptypb.Empty))
 		if err != nil || verify == nil {
 			pluginUp[plugin.Port].Up = 0
 		}

--- a/monitoring/prometheus/metric_test.go
+++ b/monitoring/prometheus/metric_test.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	pluginpb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	"github.com/dsrvlabs/vatz/manager/config"
 	"reflect"
 	"testing"
@@ -20,12 +21,13 @@ func Test_prometheusManager_getPluginUp(t *testing.T) {
 		args         args
 		wantPluginUp map[int]*prometheusValue
 	}
+	var grpcClients []pluginpb.PluginClient
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &prometheusManager{
 				Protocol: tt.fields.Protocol,
 			}
-			if gotPluginUp := c.getPluginUp(tt.args.plugins, tt.args.hostName); !reflect.DeepEqual(gotPluginUp, tt.wantPluginUp) {
+			if gotPluginUp := c.getPluginUp(tt.args.plugins, tt.args.hostName, grpcClients); !reflect.DeepEqual(gotPluginUp, tt.wantPluginUp) {
 				t.Errorf("getPluginUp() = %v, want %v", gotPluginUp, tt.wantPluginUp)
 			}
 		})

--- a/monitoring/prometheus/metric_test.go
+++ b/monitoring/prometheus/metric_test.go
@@ -1,7 +1,6 @@
 package prometheus
 
 import (
-	pluginpb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	"github.com/dsrvlabs/vatz/manager/config"
 	"reflect"
 	"testing"
@@ -21,13 +20,13 @@ func Test_prometheusManager_getPluginUp(t *testing.T) {
 		args         args
 		wantPluginUp map[int]*prometheusValue
 	}
-	var grpcClients []pluginpb.PluginClient
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &prometheusManager{
 				Protocol: tt.fields.Protocol,
 			}
-			if gotPluginUp := c.getPluginUp(tt.args.plugins, tt.args.hostName, grpcClients); !reflect.DeepEqual(gotPluginUp, tt.wantPluginUp) {
+			if gotPluginUp := c.getPluginUp(tt.args.plugins, tt.args.hostName); !reflect.DeepEqual(gotPluginUp, tt.wantPluginUp) {
 				t.Errorf("getPluginUp() = %v, want %v", gotPluginUp, tt.wantPluginUp)
 			}
 		})

--- a/monitoring/prometheus/metric_test.go
+++ b/monitoring/prometheus/metric_test.go
@@ -2,6 +2,7 @@ package prometheus
 
 import (
 	"github.com/dsrvlabs/vatz/manager/config"
+	"github.com/dsrvlabs/vatz/utils"
 	"reflect"
 	"testing"
 )
@@ -20,13 +21,13 @@ func Test_prometheusManager_getPluginUp(t *testing.T) {
 		args         args
 		wantPluginUp map[int]*prometheusValue
 	}
-
+	var grpcClientWithPlugins []utils.GClientWithPlugin
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &prometheusManager{
 				Protocol: tt.fields.Protocol,
 			}
-			if gotPluginUp := c.getPluginUp(tt.args.plugins, tt.args.hostName); !reflect.DeepEqual(gotPluginUp, tt.wantPluginUp) {
+			if gotPluginUp := c.getPluginUp(tt.args.hostName, grpcClientWithPlugins); !reflect.DeepEqual(gotPluginUp, tt.wantPluginUp) {
 				t.Errorf("getPluginUp() = %v, want %v", gotPluginUp, tt.wantPluginUp)
 			}
 		})

--- a/monitoring/prometheus/prometheus.go
+++ b/monitoring/prometheus/prometheus.go
@@ -2,6 +2,7 @@ package prometheus
 
 import (
 	"github.com/dsrvlabs/vatz/manager/config"
+	"github.com/dsrvlabs/vatz/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -47,8 +48,8 @@ func (cc prometheusManagerCollector) Collect(ch chan<- prometheus.Metric) {
 			[]string{"plugin", "port", "host_name"}, nil,
 		)
 	)
-
-	upByPlugin := cc.prometheusManager.getPluginUp(config.GetConfig().PluginInfos.Plugins, config.GetConfig().Vatz.NotificationInfo.HostName)
+	gClientInfos := utils.GetClients(config.GetConfig().PluginInfos.Plugins)
+	upByPlugin := cc.prometheusManager.getPluginUp(config.GetConfig().Vatz.NotificationInfo.HostName, gClientInfos)
 
 	for port, value := range upByPlugin {
 		ch <- prometheus.MustNewConstMetric(

--- a/monitoring/prometheus/prometheus_test.go
+++ b/monitoring/prometheus/prometheus_test.go
@@ -1,7 +1,6 @@
 package prometheus
 
 import (
-	pluginpb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"reflect"
 	"testing"
@@ -18,10 +17,9 @@ func TestInitPrometheusServer(t *testing.T) {
 		args    args
 		wantErr bool
 	}
-	var grpcClients []pluginpb.PluginClient
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := InitPrometheusServer(tt.args.addr, tt.args.port, tt.args.protocol, grpcClients); (err != nil) != tt.wantErr {
+			if err := InitPrometheusServer(tt.args.addr, tt.args.port, tt.args.protocol); (err != nil) != tt.wantErr {
 				t.Errorf("InitPrometheusServer() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -38,10 +36,10 @@ func Test_newPrometheusManager(t *testing.T) {
 		args args
 		want *prometheusManager
 	}
-	var grpcClients []pluginpb.PluginClient
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := newPrometheusManager(tt.args.protocol, tt.args.reg, grpcClients); !reflect.DeepEqual(got, tt.want) {
+			if got := newPrometheusManager(tt.args.protocol, tt.args.reg); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("newPrometheusManager() = %v, want %v", got, tt.want)
 			}
 		})

--- a/monitoring/prometheus/prometheus_test.go
+++ b/monitoring/prometheus/prometheus_test.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	pluginpb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	"github.com/prometheus/client_golang/prometheus"
 	"reflect"
 	"testing"
@@ -17,9 +18,10 @@ func TestInitPrometheusServer(t *testing.T) {
 		args    args
 		wantErr bool
 	}
+	var grpcClients []pluginpb.PluginClient
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := InitPrometheusServer(tt.args.addr, tt.args.port, tt.args.protocol); (err != nil) != tt.wantErr {
+			if err := InitPrometheusServer(tt.args.addr, tt.args.port, tt.args.protocol, grpcClients); (err != nil) != tt.wantErr {
 				t.Errorf("InitPrometheusServer() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -36,9 +38,10 @@ func Test_newPrometheusManager(t *testing.T) {
 		args args
 		want *prometheusManager
 	}
+	var grpcClients []pluginpb.PluginClient
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := newPrometheusManager(tt.args.protocol, tt.args.reg); !reflect.DeepEqual(got, tt.want) {
+			if got := newPrometheusManager(tt.args.protocol, tt.args.reg, grpcClients); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("newPrometheusManager() = %v, want %v", got, tt.want)
 			}
 		})

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -65,7 +65,6 @@ func GetClients(plugins []config.Plugin) []pluginpb.PluginClient {
 	var (
 		grpcClients      []pluginpb.PluginClient
 		wg               sync.WaitGroup
-		mutex            sync.Mutex
 		connectionCancel = 10
 	)
 
@@ -88,14 +87,11 @@ func GetClients(plugins []config.Plugin) []pluginpb.PluginClient {
 				fmt.Printf("Connection to %s failed: %v\n", addr, err)
 				return
 			}
-
 			// Create a context for the connection check.
-			mutex.Lock()
 			grpcClients = append(grpcClients, pluginpb.NewPluginClient(conn))
 			if conn.GetState() == connectivity.Ready {
 				log.Info().Str("module", "util").Msgf("Client connected to plugin: %s successfully with address %s", name, addr)
 			}
-			mutex.Unlock()
 		}(pluginAddress, plugin.Name)
 	}
 	wg.Wait()

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -109,7 +109,7 @@ func waitForConnection(ctx context.Context, conn *grpc.ClientConn) error {
 
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("Connection timeout")
+			return fmt.Errorf("Connection is timed out. Please Check your plugin status. ")
 		default:
 			// Wait a short period before checking the connection state again.
 			time.Sleep(100 * time.Millisecond)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	pluginpb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	"github.com/dsrvlabs/vatz/manager/config"
@@ -94,12 +95,12 @@ func GetClients(plugins []config.Plugin) []GClientWithPlugin {
 
 			// Block until the connection is ready or until the context times out.
 			if err := waitForConnection(ctx, conn); err != nil {
-				fmt.Printf("Connection to %s failed: %v\n", addr, err)
+				log.Error().Str("module", "util").Msgf("Connection to %s (plugin:%s) failed: %v\n", addr, configPlugin.Name, err)
 				return
 			}
 
 			if conn.GetState() == connectivity.Ready {
-				log.Info().Str("module", "util").Msgf("Client connected to plugin: %s successfully with address %s", configPlugin.Name, addr)
+				log.Info().Str("module", "util").Msgf("Client successfully connected to %s (plugin:%s).", addr, configPlugin.Name)
 			}
 		}(pluginAddress, plugin)
 	}
@@ -118,7 +119,8 @@ func waitForConnection(ctx context.Context, conn *grpc.ClientConn) error {
 
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("Connection is timed out. Please Check your plugins' status. ")
+			log.Error().Str("module", "util").Msg("Connection is timed out. Please Check your plugins' status. ")
+			return errors.New("")
 		default:
 			// Wait a short period before checking the connection state again.
 			time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Enhancement
- [ ] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

**Related:** # (issue)
close #312
close #503 
**Summary**

Print log that if client to plugin connected succesfully. 

---

### 3. Comments
> Please, leave a comments if there's further action that requires. 


## 1. Coverage test
```
 ✘ dongyookang DK 👑   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-312-re ±
 make coverage
?       github.com/dsrvlabs/vatz        [no test files]
?       github.com/dsrvlabs/vatz/manager/types  [no test files]
?       github.com/dsrvlabs/vatz/mocks  [no test files]
ok      github.com/dsrvlabs/vatz/cmd    6.020s  coverage: 23.4% of statements
ok      github.com/dsrvlabs/vatz/manager/api    0.768s  coverage: 0.0% of statements [no tests to run]
ok      github.com/dsrvlabs/vatz/manager/config 0.626s  coverage: 77.8% of statements
ok      github.com/dsrvlabs/vatz/manager/dispatcher     0.934s  coverage: 7.1% of statements
ok      github.com/dsrvlabs/vatz/manager/executor       1.101s  coverage: 67.9% of statements
ok      github.com/dsrvlabs/vatz/manager/healthcheck    1.973s  coverage: 46.5% of statements
ok      github.com/dsrvlabs/vatz/manager/plugin 11.784s coverage: 51.0% of statements
ok      github.com/dsrvlabs/vatz/monitoring/prometheus  1.465s  coverage: 0.0% of statements
ok      github.com/dsrvlabs/vatz/rpc    2.287s  coverage: 67.2% of statements
ok      github.com/dsrvlabs/vatz/utils  1.619s  coverage: 3.6% of statements
 dongyookang DK 👑   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-312-re
 

```


## 2. log with grpc clients to plugins 

### 2.1 When VATZ successes  to create a connection to plugin 
```
 ./vatz start
2023-10-01T02:52:41-05:00 INF Initialize Server module=main
2023-10-01T02:52:41-05:00 INF Start VATZ Server on Listening Port: :9090 module=main
2023-10-01T02:52:41-05:00 INF Client Connected to Plugin: cpu_monitor successfully with address localhost:9001 module=util
2023-10-01T02:52:41-05:00 INF start metric server: 127.0.0.1:18080 module=main
2023-10-01T02:52:41-05:00 INF start rpc server module=rpc
2023-10-01T02:52:41-05:00 INF start gRPC server 127.0.0.1:19090 module=rpc
2023-10-01T02:52:41-05:00 INF start gRPC gateway server 127.0.0.1:19091 module=rpc
2023-10-01T02:52:42-05:00 INF Client Connected to Plugin: cpu_monitor successfully with address localhost:9001 module=util
2023-10-01T02:52:50-05:00 INF Executor send request to cpu_monitor module=executor
2023-10-01T02:52:50-05:00 INF response: SUCCESS module=executor

```
### 2.2 When VATZ fails to create a connection to plugin 
```
 ./vatz start
2023-10-02T20:20:26-05:00 INF Initialize Server module=main
2023-10-02T20:20:26-05:00 INF Start VATZ Server on Listening Port: :9090 module=main
Connection to localhost:9001 failed: Connection is timed out. Please Check your plugin status. 
2023-10-02T20:20:36-05:00 INF start metric server: 127.0.0.1:18080 module=main
2023-10-02T20:20:36-05:00 INF start rpc server module=rpc
2023-10-02T20:20:36-05:00 INF start gRPC gateway server 127.0.0.1:19091 module=rpc
2023-10-02T20:20:36-05:00 INF start gRPC server 127.0.0.1:19090 module=rpc
Connection to localhost:9001 failed: Connection is timed out. Please Check your plugin status. 
^C

```

## 3. found that Vatz create a grpc clients twice from executor, and metric, but both grpc connections are basically doing the same things. 
so update codes again to use single grpc clients to plugins 

```
 make coverage
?       github.com/dsrvlabs/vatz        [no test files]
?       github.com/dsrvlabs/vatz/manager/types  [no test files]
?       github.com/dsrvlabs/vatz/mocks  [no test files]
ok      github.com/dsrvlabs/vatz/cmd    1.213s  coverage: 23.4% of statements
ok      github.com/dsrvlabs/vatz/manager/api    0.390s  coverage: 0.0% of statements [no tests to run]
ok      github.com/dsrvlabs/vatz/manager/config 0.515s  coverage: 77.8% of statements
ok      github.com/dsrvlabs/vatz/manager/dispatcher     0.665s  coverage: 7.1% of statements
ok      github.com/dsrvlabs/vatz/manager/executor       0.801s  coverage: 67.9% of statements
ok      github.com/dsrvlabs/vatz/manager/healthcheck    0.931s  coverage: 46.5% of statements
ok      github.com/dsrvlabs/vatz/manager/plugin 5.503s  coverage: 51.0% of statements
ok      github.com/dsrvlabs/vatz/monitoring/prometheus  1.071s  coverage: 0.0% of statements
ok      github.com/dsrvlabs/vatz/rpc    2.358s  coverage: 67.2% of statements
ok      github.com/dsrvlabs/vatz/utils  1.495s  coverage: 3.6% of statements
```

> After update VATZ doesn't produce more than a client group to plugins
### 3.1. When VATZ successes  to create a connection to plugin  

```
 ./vatz start 
2023-10-02T22:00:18-05:00 INF Initialize Server module=main
2023-10-02T22:00:18-05:00 INF Start VATZ Server on Listening Port: :9090 module=main
2023-10-02T22:00:18-05:00 INF Client connected to plugin: cpu_monitor successfully with address localhost:9001 module=util
2023-10-02T22:00:18-05:00 INF start metric server: 127.0.0.1:18080 module=main
2023-10-02T22:00:18-05:00 INF start rpc server module=rpc
2023-10-02T22:00:18-05:00 INF start gRPC gateway server 127.0.0.1:19091 module=rpc
2023-10-02T22:00:18-05:00 INF start gRPC server 127.0.0.1:19090 module=rpc
2023-10-02T22:00:27-05:00 INF Executor send request to cpu_monitor module=executor
2023-10-02T22:00:27-05:00 INF response: SUCCESS module=executor

```

### 3.1. When VATZ fails  to create a connection to plugin  ( doesn't make more than single clients to plugins)

```
 ./vatz start             
2023-10-02T22:02:29-05:00 INF Initialize Server module=main
2023-10-02T22:02:29-05:00 INF Start VATZ Server on Listening Port: :9090 module=main
Connection to localhost:9001 failed: Connection is timed out. Please Check your plugin status. 
2023-10-02T22:02:39-05:00 INF start metric server: 127.0.0.1:18080 module=main
2023-10-02T22:02:39-05:00 INF start rpc server module=rpc
2023-10-02T22:02:39-05:00 INF start gRPC gateway server 127.0.0.1:19091 module=rpc
2023-10-02T22:02:39-05:00 INF start gRPC server 127.0.0.1:19090 module=rpc
```