### PR TITLE
Update SDK to remove AlertTypes in CallResponse in struct

### DIFF
--- a/manager/executor/general_executor.go
+++ b/manager/executor/general_executor.go
@@ -63,8 +63,8 @@ func (s *executor) Execute(ctx context.Context, gClient pluginpb.PluginClient, p
 		pUnique := utils.MakeUniqueValue(plugin.Name, plugin.Address, plugin.Port)
 		firstExe, preStatus := s.updateState(pUnique, resp)
 
-		for _, dp := range dispatchers {
-			dp.SetDispatcher(firstExe, preStatus, tp.NotifyInfo{
+		for _, dpSingle := range dispatchers {
+			dpSingle.SetDispatcher(firstExe, preStatus, tp.NotifyInfo{
 				Plugin:     plugin.Name,
 				Method:     method.Name,
 				Address:    plugin.Address,
@@ -86,7 +86,6 @@ func (s *executor) execute(ctx context.Context, gClient pluginpb.PluginClient, i
 		return &pluginpb.ExecuteResponse{
 			State:        pluginpb.STATE_FAILURE,
 			Message:      "API Execution Failed",
-			AlertType:    []pluginpb.ALERT_TYPE{pluginpb.ALERT_TYPE_DISCORD, pluginpb.ALERT_TYPE_PAGER_DUTY},
 			Severity:     pluginpb.SEVERITY_ERROR,
 			ResourceType: "ResourceType Unknown",
 		}, nil

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -74,8 +74,7 @@ func pluginFeature(info, option map[string]*structpb.Value) (sdk.CallResponse, e
                 FuncName:   "YOUR_FUNCTION_NAME",
                 Message:    "YOUR_MESSAGE_CONTENTS",
                 Severity:   pluginpb.SEVERITY_UNKNOWN,
-                State:      pluginpb.STATE_NONE,
-                AlertTypes: []pluginpb.ALERT_TYPE{pluginpb.ALERT_TYPE_DISCORD},
+                State:      pluginpb.STATE_NONE
         }
 
         return ret, nil

--- a/sdk/grpc.go
+++ b/sdk/grpc.go
@@ -51,7 +51,6 @@ func (s *grpcServer) Execute(ctx context.Context, req *pb.ExecuteRequest) (*pb.E
 
 		callResp, err := f(executeInfo, option)
 
-		resp.AlertType = callResp.AlertTypes
 		if err != nil {
 			resp.Severity = pb.SEVERITY_ERROR
 			resp.State = pb.STATE_FAILURE

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -33,11 +33,10 @@ type Plugin interface {
 
 // CallResponse represents return value of callback function.
 type CallResponse struct {
-	FuncName   string                `json:"func_name"`
-	Message    string                `json:"msg"`
-	Severity   pluginpb.SEVERITY     `json:"severity"`
-	State      pluginpb.STATE        `json:"state"`
-	AlertTypes []pluginpb.ALERT_TYPE `json:"alert_types"`
+	FuncName string            `json:"func_name"`
+	Message  string            `json:"msg"`
+	Severity pluginpb.SEVERITY `json:"severity"`
+	State    pluginpb.STATE    `json:"state"`
 }
 
 type plugin struct {

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -54,9 +54,8 @@ func TestInvokeCallback(t *testing.T) {
 	}{
 		{
 			MockResp: CallResponse{
-				State:      pb.STATE_SUCCESS,
-				Message:    "hello world",
-				AlertTypes: []pb.ALERT_TYPE{pb.ALERT_TYPE_DISCORD},
+				State:   pb.STATE_SUCCESS,
+				Message: "hello world",
 			},
 			MockErr: nil,
 		},
@@ -94,7 +93,6 @@ func TestInvokeCallback(t *testing.T) {
 		// Asserts
 		assert.Nil(t, err)
 
-		assert.Equal(t, test.MockResp.AlertTypes, resp.AlertType)
 		if test.MockErr == nil {
 			assert.Equal(t, test.MockResp.State, resp.State)
 			assert.Equal(t, test.MockResp.Message, resp.Message)


### PR DESCRIPTION
### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Enhancement
- [ ] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

**Related:** # (issue)
related #499 

**Summary**
in the response, there' AlertType which doesn't used anywhere. 
so trying to remove it. 

---

### 3. Comments
> Please, leave a comments if there's further action that requires. 

```
 dongyookang DK 🚦   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-499
 make coverage
?       github.com/dsrvlabs/vatz        [no test files]
?       github.com/dsrvlabs/vatz/manager/types  [no test files]
?       github.com/dsrvlabs/vatz/mocks  [no test files]
ok      github.com/dsrvlabs/vatz/cmd    2.343s  coverage: 23.3% of statements
ok      github.com/dsrvlabs/vatz/manager/api    0.686s  coverage: 0.0% of statements [no tests to run]
ok      github.com/dsrvlabs/vatz/manager/config 0.551s  coverage: 77.8% of statements
ok      github.com/dsrvlabs/vatz/manager/dispatcher     0.830s  coverage: 7.1% of statements
ok      github.com/dsrvlabs/vatz/manager/executor       1.109s  coverage: 67.9% of statements
ok      github.com/dsrvlabs/vatz/manager/healthcheck    1.245s  coverage: 46.5% of statements
ok      github.com/dsrvlabs/vatz/manager/plugin 7.231s  coverage: 51.0% of statements
ok      github.com/dsrvlabs/vatz/monitoring/prometheus  1.532s  coverage: 0.0% of statements
ok      github.com/dsrvlabs/vatz/rpc    2.714s  coverage: 67.2% of statements
ok      github.com/dsrvlabs/vatz/utils  0.964s  coverage: 3.6% of statements
 dongyookang DK 🚦   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-499

```

```
 make coverage
go test -v -coverprofile=cover.out
=== RUN   TestRegister
2023-10-06T22:37:31-05:00 INF Register module=grpc
2023-10-06T22:37:31-05:00 INF Register module=grpc
2023-10-06T22:37:31-05:00 INF Register module=grpc
2023-10-06T22:37:31-05:00 INF Register module=grpc
2023-10-06T22:37:31-05:00 INF Register module=grpc
2023-10-06T22:37:31-05:00 INF Register module=grpc
2023-10-06T22:37:31-05:00 INF Register module=grpc
--- PASS: TestRegister (0.00s)
=== RUN   TestStartStop
2023/10/06 22:37:31 Start
2023-10-06T22:37:31-05:00 INF Start 0.0.0.0 9091 module=sdk
2023-10-06T22:37:31-05:00 INF Start module=grpc
2023-10-06T22:37:32-05:00 INF Stop module=grpc
2023-10-06T22:37:32-05:00 INF Shutting down module=grpc
2023-10-06T22:37:32-05:00 INF Stop module=grpc
2023/10/06 22:37:32 Bye
--- PASS: TestStartStop (1.00s)
=== RUN   TestVerify
--- PASS: TestVerify (0.00s)
=== RUN   TestInvokeCallback
2023-10-06T22:37:32-05:00 INF Register module=grpc
2023-10-06T22:37:32-05:00 INF Execute module=grpc
    sdk_test.go:104: PASS:      DummyCall1(map[string]*structpb.Value,map[string]*structpb.Value)
2023-10-06T22:37:32-05:00 INF Register module=grpc
2023-10-06T22:37:32-05:00 INF Execute module=grpc
    sdk_test.go:104: PASS:      DummyCall1(map[string]*structpb.Value,map[string]*structpb.Value)
--- PASS: TestInvokeCallback (0.00s)
PASS
        github.com/dsrvlabs/vatz/sdk    coverage: 94.0% of statements
ok      github.com/dsrvlabs/vatz/sdk    1.246s
 dongyookang DK 🚦   ~/ffplay/GolandProjects/xellos/vatz/sdk   ISSUE-499

```

