### PR TITLE
Throw appropriate error in command of `plugin uninstall` when plugin …

### DIFF
--- a/manager/plugin/plugin.go
+++ b/manager/plugin/plugin.go
@@ -173,8 +173,7 @@ func (m *vatzPluginManager) Uninstall(name string) error {
 		}
 		if running {
 			log.Error().Str("module", "plugin").Err(err).Msgf("Plugin %s is currently running, Please, stop plugin first.", name)
-			errorMessage := fmt.Sprintf("Please, stop plugin: %s first.", name)
-			return errors.New(errorMessage)
+			return fmt.Errorf("Please, stop plugin: %s first.", name)
 		}
 	}
 

--- a/manager/plugin/plugin.go
+++ b/manager/plugin/plugin.go
@@ -173,7 +173,8 @@ func (m *vatzPluginManager) Uninstall(name string) error {
 		}
 		if running {
 			log.Error().Str("module", "plugin").Err(err).Msgf("Plugin %s is currently running, Please, kill plugin first.", name)
-			return nil
+			errorMessage := fmt.Sprintf("Please, kill plugin: %s first.", name)
+			return errors.New(errorMessage)
 		}
 	}
 

--- a/manager/plugin/plugin.go
+++ b/manager/plugin/plugin.go
@@ -172,8 +172,8 @@ func (m *vatzPluginManager) Uninstall(name string) error {
 			return err
 		}
 		if running {
-			log.Error().Str("module", "plugin").Err(err).Msgf("Plugin %s is currently running, Please, kill plugin first.", name)
-			errorMessage := fmt.Sprintf("Please, kill plugin: %s first.", name)
+			log.Error().Str("module", "plugin").Err(err).Msgf("Plugin %s is currently running, Please, stop plugin first.", name)
+			errorMessage := fmt.Sprintf("Please, stop plugin: %s first.", name)
 			return errors.New(errorMessage)
 		}
 	}


### PR DESCRIPTION
…is up and running.

### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Enhancement
- [x] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

close #511 

**Summary**

There's was bug which shows message that doesn't make sense as below
```
 ./vatz plugin uninstall cpu_monitor        
2023-10-13T23:52:42-05:00 ERR Plugin cpu_monitor is currently running, Please, kill plugin first. module=plugin
2023-10-13T23:52:42-05:00 INF Plugin cpu_monitor is successfully uninstalled from /Users/dongyookang/.vatz module=plugin
 dongyookang DK 🍻   ~/ffplay/GolandProjects/xellos/vatz   main

```
---

### 3. Comments
> Please, leave a comments if there's further action that requires. 
```
 dongyookang DK 🍻   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-511 ±
 make coverage    
?       github.com/dsrvlabs/vatz        [no test files]
?       github.com/dsrvlabs/vatz/manager/types  [no test files]
?       github.com/dsrvlabs/vatz/mocks  [no test files]
ok      github.com/dsrvlabs/vatz/cmd    4.352s  coverage: 23.3% of statements
ok      github.com/dsrvlabs/vatz/manager/api    0.921s  coverage: 0.0% of statements [no tests to run]
ok      github.com/dsrvlabs/vatz/manager/config 0.633s  coverage: 77.8% of statements
ok      github.com/dsrvlabs/vatz/manager/dispatcher     1.368s  coverage: 7.1% of statements
ok      github.com/dsrvlabs/vatz/manager/executor       1.225s  coverage: 67.9% of statements
ok      github.com/dsrvlabs/vatz/manager/healthcheck    1.076s  coverage: 46.5% of statements
ok      github.com/dsrvlabs/vatz/manager/plugin 9.362s  coverage: 51.4% of statements
ok      github.com/dsrvlabs/vatz/monitoring/prometheus  1.509s  coverage: 0.0% of statements
ok      github.com/dsrvlabs/vatz/rpc    1.505s  coverage: 67.2% of statements
ok      github.com/dsrvlabs/vatz/utils  0.347s  coverage: 3.6% of statements
 dongyookang DK 🍻   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-511

```