### PR TITLE
Update Codes to pass Golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 COMMIT_HASH := $(shell git rev-parse --short HEAD)
 LDFLAGS := -ldflags="-X 'github.com/dsrvlabs/vatz/utils.Version=$(BRANCH)' -X 'github.com/dsrvlabs/vatz/utils.Commit=$(COMMIT_HASH)'"
 
-.PHONY: test build coverage clean
+.PHONY: test build coverage clean lint
 
 all: test coverage build
 
@@ -19,3 +19,6 @@ build:
 
 clean:
 	go clean
+
+lint:
+	golangci-lint run --timeout 5m	

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -19,20 +19,18 @@ const (
 )
 
 var (
-	healthChecker          = health.GetHealthChecker()
-	executor               = ex.NewExecutor()
-	dispatchers            []dp.Dispatcher
-	defaultVerifyInterval  = 15
-	defaultExecuteInterval = 30
-	IsDebugLevel           bool
-	IsTraceLevel           bool
-	configFile             string
-	logfile                string
-	vatzRPC                string
-	promPort               string
+	healthChecker = health.GetHealthChecker()
+	executor      = ex.NewExecutor()
+	dispatchers   []dp.Dispatcher
+	isDebugLevel  bool
+	isTraceLevel  bool
+	configFile    string
+	logfile       string
+	vatzRPC       string
+	promPort      string
 )
 
-/*	GetRootCommand: Return Cobra Root command include all subcommands .*/
+// GetRootCommand is Return Cobra Root command include all subcommands .
 func GetRootCommand() *cobra.Command {
 	rootCmd := CreateRootCommand()
 	rootCmd.AddCommand(createInitCommand(tp.LIVE))
@@ -42,16 +40,16 @@ func GetRootCommand() *cobra.Command {
 	return rootCmd
 }
 
-/*	CreateRootCommand: Create Root command which initialize root command and global flags. */
+// CreateRootCommand is Create Root command which initialize root command and global flags.
 func CreateRootCommand() *cobra.Command {
 	rootCmd := &cobra.Command{PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		if IsDebugLevel {
+		if isDebugLevel {
 			utils.SetGlobalLogLevel(zerolog.DebugLevel)
-		} else if IsTraceLevel {
+		} else if isTraceLevel {
 			utils.SetGlobalLogLevel(zerolog.TraceLevel)
 		}
 	}}
-	rootCmd.PersistentFlags().BoolVarP(&IsDebugLevel, "debug", "", false, "Enable debug mode on Log.")
-	rootCmd.PersistentFlags().BoolVarP(&IsTraceLevel, "trace", "", false, "Enable Trace mode on Log.")
+	rootCmd.PersistentFlags().BoolVarP(&isDebugLevel, "debug", "", false, "Enable debug mode on Log.")
+	rootCmd.PersistentFlags().BoolVarP(&isTraceLevel, "trace", "", false, "Enable Trace mode on Log.")
 	return rootCmd
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -152,7 +152,10 @@ func createInitCommand(initializer tp.Initializer) *cobra.Command {
 				return err
 			}
 
-			config.InitConfig(filename)
+			_, err = config.InitConfig(filename)
+			if err != nil {
+				return err
+			}
 
 			pluginDir, err := config.GetConfig().Vatz.AbsoluteHomePath()
 			if err != nil {

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/dsrvlabs/vatz/utils"
 	"io"
 	"net/http"
 	"os"
+
+	"github.com/dsrvlabs/vatz/utils"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -288,15 +289,30 @@ func createPluginCommand() *cobra.Command {
 	startCommand.PersistentFlags().StringP("args", "a", "", "Arguments")
 	startCommand.PersistentFlags().StringP("log", "l", "", "Logfile")
 
-	viper.BindPFlag("start_plugin", startCommand.PersistentFlags().Lookup("plugin"))
-	viper.BindPFlag("start_args", startCommand.PersistentFlags().Lookup("args"))
-	viper.BindPFlag("start_log", startCommand.PersistentFlags().Lookup("log"))
+	err := viper.BindPFlag("start_plugin", startCommand.PersistentFlags().Lookup("plugin"))
+	if err != nil {
+		log.Error().Str("module", "plugin").Err(err)
+	}
+	err = viper.BindPFlag("start_args", startCommand.PersistentFlags().Lookup("args"))
+	if err != nil {
+		log.Error().Str("module", "plugin").Err(err)
+	}
+	err = viper.BindPFlag("start_log", startCommand.PersistentFlags().Lookup("log"))
+	if err != nil {
+		log.Error().Str("module", "plugin").Err(err)
+	}
 
 	stopCommand.PersistentFlags().StringP("plugin", "p", "", "Installed plugin name")
-	viper.BindPFlag("stop_plugin", stopCommand.PersistentFlags().Lookup("plugin"))
+	err = viper.BindPFlag("stop_plugin", stopCommand.PersistentFlags().Lookup("plugin"))
+	if err != nil {
+		log.Error().Str("module", "plugin").Err(err)
+	}
 
 	installCommand.PersistentFlags().StringP("version", "v", "", "Installed plugin version")
-	viper.BindPFlag("plugin_version", installCommand.PersistentFlags().Lookup("version"))
+	err = viper.BindPFlag("plugin_version", installCommand.PersistentFlags().Lookup("version"))
+	if err != nil {
+		log.Error().Str("module", "plugin").Err(err)
+	}
 
 	cmd.AddCommand(statusCommand)
 	cmd.AddCommand(installCommand)

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -13,7 +13,9 @@ func TestPluginInstall(t *testing.T) {
 	defer os.Remove("cosmos-status")
 	defer os.Remove("./vatz-test.db")
 
-	config.InitConfig("../default.yaml")
+	_, err := config.InitConfig("../default.yaml")
+	assert.Nil(t, err)
+
 	cfg := config.GetConfig()
 	cfg.Vatz.HomePath = os.Getenv("PWD")
 	// pluginDir = os.Getenv("PWD")
@@ -26,7 +28,7 @@ func TestPluginInstall(t *testing.T) {
 		"github.com/dsrvlabs/vatz-plugin-cosmoshub/plugins/node_active_status",
 		"cosmos-status"})
 
-	err := root.Execute()
+	err = root.Execute()
 	assert.Nil(t, err)
 }
 

--- a/manager/executor/executor_test.go
+++ b/manager/executor/executor_test.go
@@ -64,10 +64,12 @@ func TestExecutorSuccess(t *testing.T) {
 		mockExeInfo, err := structpb.NewStruct(map[string]interface{}{
 			"execute_method": testMethodName,
 		})
+		assert.Nil(t, err)
 
 		mockOpts, err := structpb.NewStruct(map[string]interface{}{
 			"plugin_name": testPluginName,
 		})
+		assert.Nil(t, err)
 
 		exeReq := pluginpb.ExecuteRequest{
 			ExecuteInfo: mockExeInfo,
@@ -98,7 +100,7 @@ func TestExecutorSuccess(t *testing.T) {
 
 		err = e.Execute(ctx, &mockClient, cfgPlugin, mockNotifs)
 
-		fmt.Println("Status", e.status)
+		fmt.Println("Status", &e.status)
 
 		// Asserts
 		mockClient.AssertExpectations(t)
@@ -185,10 +187,12 @@ func TestExecutorFailure(t *testing.T) {
 		mockExeInfo, err := structpb.NewStruct(map[string]interface{}{
 			"execute_method": testMethodName,
 		})
+		assert.Nil(t, err)
 
 		mockOpts, err := structpb.NewStruct(map[string]interface{}{
 			"plugin_name": testPluginName,
 		})
+		assert.Nil(t, err)
 
 		exeReq := pluginpb.ExecuteRequest{
 			ExecuteInfo: mockExeInfo,
@@ -210,7 +214,7 @@ func TestExecutorFailure(t *testing.T) {
 
 		err = e.Execute(ctx, &mockClient, cfgPlugin, mockNotifs)
 
-		fmt.Println("Status", e.status)
+		fmt.Println("Status", &e.status)
 
 		// Asserts
 		mockClient.AssertExpectations(t)

--- a/manager/executor/general_executor.go
+++ b/manager/executor/general_executor.go
@@ -2,9 +2,10 @@ package executor
 
 import (
 	"context"
-	"github.com/rs/zerolog"
 	"os"
 	"sync"
+
+	"github.com/rs/zerolog"
 
 	pluginpb "github.com/dsrvlabs/vatz-proto/plugin/v1"
 	"github.com/dsrvlabs/vatz/manager/config"
@@ -64,7 +65,7 @@ func (s *executor) Execute(ctx context.Context, gClient pluginpb.PluginClient, p
 		firstExe, preStatus := s.updateState(pUnique, resp)
 
 		for _, dpSingle := range dispatchers {
-			dpSingle.SetDispatcher(firstExe, preStatus, tp.NotifyInfo{
+			err = dpSingle.SetDispatcher(firstExe, preStatus, tp.NotifyInfo{
 				Plugin:     plugin.Name,
 				Method:     method.Name,
 				Address:    plugin.Address,
@@ -73,6 +74,7 @@ func (s *executor) Execute(ctx context.Context, gClient pluginpb.PluginClient, p
 				State:      resp.GetState(),
 				ExecuteMsg: resp.GetMessage(),
 			})
+			log.Error().Str("module", "dispatcher").Msgf("failed to set dispatcher: %v", err)
 		}
 	}
 

--- a/manager/plugin/db_test.go
+++ b/manager/plugin/db_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func TestDBWrite(t *testing.T) {
-	initDB(pluginDBName)
+	err := initDB(pluginDBName)
+	assert.Nil(t, err)
+
 	defer os.Remove(pluginDBName)
 
 	wr, err := newWriter(pluginDBName)
@@ -61,7 +63,9 @@ func TestDBWrite(t *testing.T) {
 // TODO: Handle already exist.
 
 func TestDBList(t *testing.T) {
-	initDB(pluginDBName)
+	err := initDB(pluginDBName)
+	assert.Nil(t, err)
+
 	defer os.Remove(pluginDBName)
 
 	wr, err := newWriter(pluginDBName)

--- a/manager/plugin/plugin.go
+++ b/manager/plugin/plugin.go
@@ -84,7 +84,7 @@ func (m *vatzPluginManager) Install(repo, name, version string) error {
 
 	err := exeCmd.Run()
 	if err != nil {
-		log.Error().Str("module", "plugin").Msgf("Install > exeCmd.Run Error: %s", string(stderr.Bytes()))
+		log.Error().Str("module", "plugin").Msgf("Install > exeCmd.Run Error: %s", stderr.String())
 		return err
 	}
 
@@ -332,7 +332,11 @@ func NewManager(vatzHome string) VatzPluginManager {
 		if err != nil {
 			log.Error().Str("module", "plugin").Msgf("NewManager > newWriter Error: %s", err)
 		}
-		dbWr.MigratePluginTable()
+		err = dbWr.MigratePluginTable()
+		if err != nil {
+			log.Error().Str("module", "plugin").Msgf("NewManager > MigratePluginTable Error: %s", err)
+		}
+
 	}
 	return pManager
 }

--- a/manager/plugin/plugin_test.go
+++ b/manager/plugin/plugin_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestPluginManager(t *testing.T) {
-	initDB(pluginDBName)
+	err := initDB(pluginDBName)
+	assert.Nil(t, err)
 
 	defer func() {
 		os.Remove("./active_status")
@@ -27,7 +28,7 @@ func TestPluginManager(t *testing.T) {
 	binName := "cosmos-active"
 
 	mgr := NewManager(os.Getenv("PWD"))
-	err := mgr.Install(repo, binName, "latest")
+	err = mgr.Install(repo, binName, "latest")
 	assert.Nil(t, err)
 
 	_, err = os.Open("./active_status")
@@ -77,7 +78,8 @@ func TestPluginManager(t *testing.T) {
 }
 
 func TestPluginList(t *testing.T) {
-	initDB(pluginDBName)
+	err := initDB(pluginDBName)
+	assert.Nil(t, err)
 
 	defer func() {
 		os.Remove(pluginDBName)

--- a/manager/plugin/plugin_test.go
+++ b/manager/plugin/plugin_test.go
@@ -54,9 +54,11 @@ func TestPluginManager(t *testing.T) {
 	assert.NotNil(t, ps)
 
 	pName, err := ps.Name()
+	assert.Nil(t, err)
 	assert.Equal(t, binName, pName)
 
 	isRunning, err := ps.IsRunning()
+	assert.Nil(t, err)
 	assert.True(t, isRunning)
 
 	// Test Stop

--- a/monitoring/prometheus/metric_test.go
+++ b/monitoring/prometheus/metric_test.go
@@ -1,10 +1,10 @@
 package prometheus
 
 import (
-	"github.com/dsrvlabs/vatz/manager/config"
-	"github.com/dsrvlabs/vatz/utils"
 	"reflect"
 	"testing"
+
+	"github.com/dsrvlabs/vatz/utils"
 )
 
 func Test_prometheusManager_getPluginUp(t *testing.T) {
@@ -12,7 +12,6 @@ func Test_prometheusManager_getPluginUp(t *testing.T) {
 		Protocol string
 	}
 	type args struct {
-		plugins  []config.Plugin
 		hostName string
 	}
 	var tests []struct {

--- a/monitoring/prometheus/prometheus.go
+++ b/monitoring/prometheus/prometheus.go
@@ -1,15 +1,16 @@
 package prometheus
 
 import (
+	"net/http"
+	"strconv"
+	"sync"
+
 	"github.com/dsrvlabs/vatz/manager/config"
 	"github.com/dsrvlabs/vatz/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/zerolog/log"
-	"net/http"
-	"strconv"
-	"sync"
 )
 
 type prometheusManager struct {
@@ -63,6 +64,7 @@ func (cc prometheusManagerCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
+// InitPrometheusServer initializes prometheus server
 func InitPrometheusServer(addr, port, protocol string) error {
 	log.Info().Str("module", "main").Msgf("start metric server: %s:%s", addr, port)
 

--- a/monitoring/prometheus/prometheus_test.go
+++ b/monitoring/prometheus/prometheus_test.go
@@ -1,9 +1,10 @@
 package prometheus
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
 	"reflect"
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestInitPrometheusServer(t *testing.T) {
@@ -51,7 +52,7 @@ func Test_prometheusManagerCollector_Collect(t *testing.T) {
 		prometheusManager *prometheusManager
 	}
 	type args struct {
-		ch chan<- prometheus.Metric
+		prometheus.Metric
 	}
 	var tests []struct {
 		name   string
@@ -72,7 +73,7 @@ func Test_prometheusManagerCollector_Describe(t *testing.T) {
 		prometheusManager *prometheusManager
 	}
 	type args struct {
-		ch chan<- *prometheus.Desc
+		*prometheus.Desc
 	}
 	var tests []struct {
 		name   string

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -105,7 +105,11 @@ func (s *rpcService) Stop() {
 	defer s.cancel()
 
 	if s.httpServer != nil {
-		s.httpServer.Shutdown(s.ctx)
+		err := s.httpServer.Shutdown(s.ctx)
+		if err != nil {
+			log.Error().Str("module", "rpc").Err(err)
+		}
+
 	}
 
 	log.Info().Str("module", "rpc").Msg("stop")

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -21,7 +21,10 @@ import (
 func TestRPCs(t *testing.T) {
 	rpc := NewRPCService()
 
-	go rpc.Start("127.0.0.1", 19090, 19091)
+	go func() {
+		err := rpc.Start("127.0.0.1", 19090, 19091)
+		assert.Nil(t, err)
+	}()
 
 	time.Sleep(time.Second * 1) // Wait ready
 


### PR DESCRIPTION
### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Enhancement
- [ ] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

**Related:** # (issue)
close #344 

**Summary**
Update Codes to pass Golint

---

### 3. Comments
> Please, leave a comments if there's further action that requires. 

```shell
hg  ~/workspace/vatz   lint  golangci-lint run -v              
INFO [config_reader] Config search paths: [./ /Users/hg/workspace/vatz /Users/hg/workspace /Users/hg /Users /] 
INFO [lintersdb] Active 9 linters: [deadcode errcheck gosimple govet ineffassign staticcheck typecheck unused varcheck] 
INFO [loader] Go packages loading at mode 575 (exports_file|imports|name|types_sizes|compiled_files|deps|files) took 449.86046ms 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 5.367997ms 
INFO [linters context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 21, after processing: 0 
INFO [runner] Processors filtering stat (out/in): autogenerated_exclude: 21/21, exclude: 21/21, exclude-rules: 0/21, path_prettifier: 21/21, identifier_marker: 21/21, cgo: 21/21, filename_unadjuster: 21/21, skip_files: 21/21, skip_dirs: 21/21 
INFO [runner] processing took 679.588µs with stages: identifier_marker: 235.984µs, autogenerated_exclude: 195.417µs, path_prettifier: 153.163µs, skip_dirs: 43.424µs, exclude-rules: 38.736µs, cgo: 4.431µs, filename_unadjuster: 2.994µs, nolint: 2.563µs, max_same_issues: 667ns, max_from_linter: 298ns, uniq_by_line: 285ns, skip_files: 253ns, source_code: 218ns, severity-rules: 196ns, diff: 190ns, exclude: 184ns, max_per_file_from_linter: 183ns, path_shortener: 162ns, sort_results: 134ns, path_prefixer: 106ns 
INFO [runner] linters took 126.621748ms with stages: goanalysis_metalinter: 125.877424ms 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 7 samples, avg is 58.1MB, max is 61.5MB 
INFO Execution took 599.658798ms  
``` 