### PR TITLE
Print ERR failed to set dispatcher: <nil> module=dispatcher even if t…

### DIFF
--- a/manager/executor/general_executor.go
+++ b/manager/executor/general_executor.go
@@ -74,7 +74,9 @@ func (s *executor) Execute(ctx context.Context, gClient pluginpb.PluginClient, p
 				State:      resp.GetState(),
 				ExecuteMsg: resp.GetMessage(),
 			})
-			log.Error().Str("module", "dispatcher").Msgf("failed to set dispatcher: %v", err)
+			if err != nil {
+				log.Error().Str("module", "dispatcher").Msgf("failed to set dispatcher: %v", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
…here's no error

### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Enhancement
- [x] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

close: #520 

**Summary**

There's was wrong Error message that print Error message even if there's no Error on executor. 

---

### 3. Comments
> Please, leave a comments if there's further action that requires. 

```
 dongyookang DK 🍻   ~/ffplay/GolandProjects/xellos/vatz   main
 make coverage
?       github.com/dsrvlabs/vatz        [no test files]
?       github.com/dsrvlabs/vatz/manager/types  [no test files]
?       github.com/dsrvlabs/vatz/mocks  [no test files]
ok      github.com/dsrvlabs/vatz/cmd    6.206s  coverage: 23.7% of statements
ok      github.com/dsrvlabs/vatz/manager/api    3.952s  coverage: 0.0% of statements [no tests to run]
ok      github.com/dsrvlabs/vatz/manager/config 3.026s  coverage: 77.8% of statements
ok      github.com/dsrvlabs/vatz/manager/dispatcher     4.417s  coverage: 6.9% of statements
ok      github.com/dsrvlabs/vatz/manager/executor       6.265s  coverage: 65.5% of statements
ok      github.com/dsrvlabs/vatz/manager/healthcheck    3.498s  coverage: 44.4% of statements
ok      github.com/dsrvlabs/vatz/manager/plugin 11.248s coverage: 51.0% of statements
ok      github.com/dsrvlabs/vatz/monitoring/prometheus  5.811s  coverage: 0.0% of statements
ok      github.com/dsrvlabs/vatz/rpc    6.358s  coverage: 65.0% of statements
ok      github.com/dsrvlabs/vatz/utils  2.571s  coverage: 3.6% of statements
 dongyookang DK 🍻   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-520
 
```

```
 ✘ dongyookang DK 🍻   ~/ffplay/GolandProjects/xellos/vatz   ISSUE-520
 ./vatz start
2023-10-23T21:27:01-05:00 INF Initialize Server module=main
2023-10-23T21:27:01-05:00 INF Start VATZ Server on Listening Port: :9090 module=main
2023-10-23T21:27:01-05:00 INF Client successfully connected to localhost:9001 (plugin:cpu_monitor). module=util
2023-10-23T21:27:01-05:00 INF start metric server: 127.0.0.1:18080 module=main
2023-10-23T21:27:01-05:00 INF start rpc server module=rpc
2023-10-23T21:27:01-05:00 INF start gRPC gateway server 127.0.0.1:19091 module=rpc
2023-10-23T21:27:01-05:00 INF start gRPC server 127.0.0.1:19090 module=rpc
2023-10-23T21:27:01-05:00 INF Client successfully connected to localhost:9001 (plugin:cpu_monitor). module=util
2023-10-23T21:27:10-05:00 INF Executor send request to cpu_monitor module=executor
2023-10-23T21:27:10-05:00 INF response: SUCCESS module=executor
2023-10-23T21:27:19-05:00 INF Executor send request to cpu_monitor module=executor
2023-10-23T21:27:19-05:00 INF response: SUCCESS module=executor
```