### PR TITLE
checkout only branch that is raised from to run make coverage test.

### DIFF
--- a/.github/workflows/ci_coverage.yml
+++ b/.github/workflows/ci_coverage.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}  # Check out the source branch of the PR
       - name: Set up Python
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Enhancement
- [x] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

**Related:** # (issue)
close #523 

**Summary**
Current coverage test is running on main branch only when PR is raised, which's wrong. 
I updated co_coverage.yml to run make test on target branch that include PR's update. 

---

### 3. Comments
> Please, leave a comments if there's further action that requires. 