### PR TITLE
Fix the github action of creation bi weekly discussion

### DIFF
--- a/.github/workflows/create-vatz-bi-weekly.yml
+++ b/.github/workflows/create-vatz-bi-weekly.yml
@@ -56,12 +56,13 @@ jobs:
         shell: bash
 
       - name: Generate new discussion
-        id: create-discussion
+        if: steps.check_latest_discussion.outputs.dis_num != ''
+        id: create_discussion
         uses: abirismyname/create-discussion@v1.1.0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
         with:
-          title: "${{ env.NEXT_MILESTONE_NUMBER }}. VATZ biweekly meeting at ${{ env.DUE_DATE }}"
+          title: "${{ steps.check_latest_discussion.outputs.dis_num }}. VATZ biweekly meeting at ${{ steps.check_meeting_date.outputs.meet_date }}"
           body: |
             ### 1. Overall
             ### 2. Statistic Rate
@@ -69,17 +70,6 @@ jobs:
             Sprint | Issue fulfillment | progress rate(%)
             --: | :--: | :--:
             
-          repository-id: "${{ secrets.DISCUSSION_REPO_ID }}"
-          category-id: "${{ secrets.DISCUSSION_CATE_ID }}"
+          repository-id: "${{ secrets.REPOSITORY_ID }}"
+          category-id: "${{ secrets.CATEGORY_ID }}"
 
-      - name: Generate new milestone
-        id: create-milestone
-        run: |
-          echo "Due Date: ${{ env.DUE_DATE }}"
-          echo "Next milestone number: ${{ env.NEXT_MILESTONE_NUMBER }}"
-          curl -s \
-            -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            "${{ env.URL }}" \
-            -d '{"title":"Sprint '${{ env.NEXT_MILESTONE_NUMBER }}' (~ '${{ env.DUE_DATE }}')","description":" ","state":"open","due_on":"'${{ env.DUE_DATE_LONG }}'"}'

--- a/.github/workflows/create-vatz-bi-weekly.yml
+++ b/.github/workflows/create-vatz-bi-weekly.yml
@@ -9,21 +9,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Check creation date # Step to determine if this is the second week because you have to create a 'Discussion & Milestone' every two weeks
+      - name: Check creation date # Step to determine if this is the second week because you have to create a 'Discussion' every two weeks
+        id: check_week
         run: |
-          due_date=`curl -Ls \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "${{ env.URL }}" | jq 'sort_by(.id)' | jq .[length-1].due_on | sed 's/"//g'`
-          target_date=$(date -d "$due_date" +%Y-%m-%d)
-          today=$(date +%Y-%m-%d)
-          if [[ "$target_date" == "$today" ]]; then
-            echo "The dates are equal."
-          else 
-            echo "The dates are different."
-            exit 1
+          WEEK_NUM=`date -d ${{ vars.START_DATE }} +%U`
+          THIS_WEEK_NUM=`date +%U`
+          DIFF_WEEK_NUM=$( expr $THIS_WEEK_NUM - $WEEK_NUM )
+
+          if [ $(( DIFF_WEEK_NUM % 2)) -eq 0 ]; then
+            echo "This is the correct week"
+            echo "is_week=true" >> $GITHUB_OUTPUT
+          else
+            echo "This is not the correct week"
+            echo "is_week=false" >> $GITHUB_OUTPUT
           fi
+        shell: bash
+
       - name: Set env variable # Generate values for all steps
         run: |
           echo "DUE_DATE=$(date --date='+14 days' +%Y-%m-%d)" >> $GITHUB_ENV

--- a/.github/workflows/create-vatz-bi-weekly.yml
+++ b/.github/workflows/create-vatz-bi-weekly.yml
@@ -55,16 +55,6 @@ jobs:
           echo "dis_num=$NEXT_NUM" >> $GITHUB_OUTPUT
         shell: bash
 
-      - name: Set env variable # Generate values for all steps
-        run: |
-          echo "DUE_DATE=$(date --date='+14 days' +%Y-%m-%d)" >> $GITHUB_ENV
-          echo "DUE_DATE_LONG=$(date --date='+14 days' +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
-          current_number=`curl -Ls \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "${{ env.URL }}" | jq 'sort_by(.id)' | jq .[length-1].title | sed 's/"//g' | awk '{print $2}'`
-          echo "NEXT_MILESTONE_NUMBER=$(( current_number + 1 ))" >> $GITHUB_ENV
       - name: Generate new discussion
         id: create-discussion
         uses: abirismyname/create-discussion@v1.1.0

--- a/.github/workflows/create-vatz-bi-weekly.yml
+++ b/.github/workflows/create-vatz-bi-weekly.yml
@@ -2,7 +2,7 @@ name: Create a next vatz discussion & milestone
 on: 
   workflow_dispatch:
   schedule:
-    - cron: "0 14 * * 3" # Every Wednesday at 11 p.m.
+    - cron: "0 2 * * 1" # Every Monday at 11 a.m(KST).
 env:
   URL: https://api.github.com/repos/dsrvlabs/vatz/milestones
 jobs:
@@ -51,6 +51,7 @@ jobs:
             
           repository-id: "${{ secrets.DISCUSSION_REPO_ID }}"
           category-id: "${{ secrets.DISCUSSION_CATE_ID }}"
+
       - name: Generate new milestone
         id: create-milestone
         run: |

--- a/.github/workflows/create-vatz-bi-weekly.yml
+++ b/.github/workflows/create-vatz-bi-weekly.yml
@@ -8,7 +8,6 @@ jobs:
   create-bi-weekly:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
       - name: Check creation date # Step to determine if this is the second week because you have to create a 'Discussion' every two weeks
         id: check_week
         run: |

--- a/.github/workflows/create-vatz-bi-weekly.yml
+++ b/.github/workflows/create-vatz-bi-weekly.yml
@@ -24,12 +24,35 @@ jobs:
             echo "is_week=false" >> $GITHUB_OUTPUT
           fi
         shell: bash
+
       - name: Get meeting date
         if: steps.check_week.outputs.is_week == 'true'
         id: check_meeting_date
         run: |
           meeting=`date -d "wed" +"%Y-%m-%d"`
           echo "meet_date=$meeting" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Get next discussion number
+        if: steps.check_week.outputs.is_week == 'true'
+        id: check_latest_discussion
+        run: |
+          # GitHub GraphQL API Endpoint
+          URL="https://api.github.com/graphql"
+          
+          # GraphQL Query
+          QUERY='{
+            "query": "query { repository(owner: \"dsrvlabs\", name: \"vatz\") { discussions(first: 1, orderBy: {field: CREATED_AT, direction: DESC}) { nodes { title url createdAt author { login } } } } }"
+          }'
+          
+          # Sending the request using curl
+          response=$(curl -s -X POST -H "Authorization: bearer ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -d "$QUERY" $URL)
+  
+          LASTEST=`echo $response | jq .data.repository.discussions.nodes[0].title | awk '{print $1 }' | sed 's/\"//g' | sed 's/\.//g'`
+  
+          NEXT_NUM=$( expr $LASTEST + 1 )
+          
+          echo "dis_num=$NEXT_NUM" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Set env variable # Generate values for all steps

--- a/.github/workflows/create-vatz-bi-weekly.yml
+++ b/.github/workflows/create-vatz-bi-weekly.yml
@@ -3,8 +3,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 2 * * 1" # Every Monday at 11 a.m(KST).
-env:
-  URL: https://api.github.com/repos/dsrvlabs/vatz/milestones
+
 jobs:
   create-bi-weekly:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-vatz-bi-weekly.yml
+++ b/.github/workflows/create-vatz-bi-weekly.yml
@@ -24,6 +24,13 @@ jobs:
             echo "is_week=false" >> $GITHUB_OUTPUT
           fi
         shell: bash
+      - name: Get meeting date
+        if: steps.check_week.outputs.is_week == 'true'
+        id: check_meeting_date
+        run: |
+          meeting=`date -d "wed" +"%Y-%m-%d"`
+          echo "meet_date=$meeting" >> $GITHUB_OUTPUT
+        shell: bash
 
       - name: Set env variable # Generate values for all steps
         run: |


### PR DESCRIPTION
### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [ ] Enhancement
- [x] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

- **Related:** #560 

**Summary**
Fix the bug about not creation the discussion.

---

### 3. Comments

Before the this github action merge, we need to set the value like below.

- Secrets
  - REPOSITORY_ID
  - CATEGORY_ID

  
- Variables
  - START_DATE=2024-06-05
  
> How to get the REPOSITORY_ID and CATEGORY_ID
> You can run the below code with editing the <YOUR_GITHUB_TOKEN>
> 
> ```sh
> #!/bin/bash
> 
> # GitHub Personal Access Token
> TOKEN=<YOUR_GITHUB_TOKEN>
> 
> # GitHub GraphQL API Endpoint
> URL="https://api.github.com/graphql"
> 
> # GraphQL Query
> QUERY='{
> "query": "query { repository(owner: \"dsrvlabs\", name: \"vatz\") { id discussionCategories(first: 10) { edges { node { id name } cursor } } } }"
> }'
> 
> # Sending the request using curl
> response=$(curl -s -X POST -H "Authorization: bearer $TOKEN" -H "Content-Type: application/json" -d "$QUERY" $URL)
> 
> # Output the response
> REPOSITORY_ID=`echo $response | jq .data.repository.id`
> CATEGORY_ID=`echo $response | jq .data.repository.discussionCategories.edges[1].node.id`
> 
> echo "REPOSITORY_ID: $REPOSITORY_ID"
> echo "CATEGORY_ID: $CATEGORY_ID"
> ```

> What is mean the START_DATE?
> A. START_DATE is the date on which Biweekly discussion is created. For example, if the standard date changes, as we did with June 5th as the new standard date, you can edit the value.
> Please enter the form as YYYY-MM-DD.