### PR TITLE
Send Notification via its Flag

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -36,6 +36,7 @@ func createInitCommand(initializer tp.Initializer) *cobra.Command {
         secret: "Put your PagerDuty's Integration Key (Events API v2)"
       - channel: "slack"
         secret: "Put Your Slack Webhook url"
+        flag: "Set your flag to send notifications per plugins individually."
       - channel: "telegram"
         secret: "Put Your Bot's Token"
         chat_id: "Put Your Chat's chat_id"
@@ -78,6 +79,7 @@ func createInitCommand(initializer tp.Initializer) *cobra.Command {
       plugin_port: 10002
       executable_methods:
         - method_name: "sampleMethod2"
+          flag: "set notification flag to dispatchers you want set."
 `
 
 			defaultPluginOptionTemplate := `plugins_infos:

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -36,8 +36,8 @@ func createInitCommand(initializer tp.Initializer) *cobra.Command {
         secret: "Put your PagerDuty's Integration Key (Events API v2)"
       - channel: "slack"
         secret: "Put Your Slack Webhook url"
-        subscription:
-		  - "Please, put pluginName that you would like subscribes for notifications"
+        subscriptions:
+          - "Please, put Plugin Name that you specifically subscribe to send notification."
       - channel: "telegram"
         secret: "Put Your Bot's Token"
         chat_id: "Put Your Chat's chat_id"

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -36,7 +36,8 @@ func createInitCommand(initializer tp.Initializer) *cobra.Command {
         secret: "Put your PagerDuty's Integration Key (Events API v2)"
       - channel: "slack"
         secret: "Put Your Slack Webhook url"
-        flag: "Set your flag to send notifications per plugins individually."
+        subscription:
+		  - "Please, put pluginName that you would like subscribes for notifications"
       - channel: "telegram"
         secret: "Put Your Bot's Token"
         chat_id: "Put Your Chat's chat_id"
@@ -79,7 +80,6 @@ func createInitCommand(initializer tp.Initializer) *cobra.Command {
       plugin_port: 10002
       executable_methods:
         - method_name: "sampleMethod2"
-          flag: "set notification flag to dispatchers you want set."
 `
 
 			defaultPluginOptionTemplate := `plugins_infos:

--- a/manager/config/config.go
+++ b/manager/config/config.go
@@ -79,7 +79,7 @@ type NotificationInfo struct {
 		Channel          string   `yaml:"channel"`
 		Secret           string   `yaml:"secret"`
 		ChatID           string   `yaml:"chat_id"`
-		Flag             string   `yaml:"flag,omitempty"`
+		Subscriptions    []string `yaml:"subscriptions,omitempty"`
 		ReminderSchedule []string `yaml:"reminder_schedule"`
 	} `yaml:"dispatch_channels"`
 }
@@ -133,7 +133,6 @@ type Plugin struct {
 	Port              int    `yaml:"plugin_port"`
 	ExecutableMethods []struct {
 		Name string `yaml:"method_name"`
-		Flag string `yaml:"flag,omitempty"`
 	} `yaml:"executable_methods"`
 }
 

--- a/manager/config/config.go
+++ b/manager/config/config.go
@@ -79,6 +79,7 @@ type NotificationInfo struct {
 		Channel          string   `yaml:"channel"`
 		Secret           string   `yaml:"secret"`
 		ChatID           string   `yaml:"chat_id"`
+		Flag             string   `yaml:"flag,omitempty"`
 		ReminderSchedule []string `yaml:"reminder_schedule"`
 	} `yaml:"dispatch_channels"`
 }
@@ -132,6 +133,7 @@ type Plugin struct {
 	Port              int    `yaml:"plugin_port"`
 	ExecutableMethods []struct {
 		Name string `yaml:"method_name"`
+		Flag string `yaml:"flag,omitempty"`
 	} `yaml:"executable_methods"`
 }
 

--- a/manager/dispatcher/discord.go
+++ b/manager/dispatcher/discord.go
@@ -36,7 +36,7 @@ type discord struct {
 	host             string
 	channel          tp.Channel
 	secret           string
-	notificationFlag string
+	subscriptions    []string
 	reminderSchedule []string
 	reminderCron     *cron.Cron
 	entry            sync.Map
@@ -51,11 +51,11 @@ func containsAny(s string, substrings []string) bool {
 	return false
 }
 
-func (d *discord) SetDispatcher(firstRunMsg bool, pluginNotificationFlag string, preStat tp.StateFlag, notifyInfo tp.NotifyInfo) error {
+func (d *discord) SetDispatcher(firstRunMsg bool, preStat tp.StateFlag, notifyInfo tp.NotifyInfo) error {
 	reqToNotify, reminderState, deliverMessage := messageHandler(firstRunMsg, preStat, notifyInfo)
 	pUnique := deliverMessage.Options["pUnique"].(string)
-	flagEnabled, sameFlagExists := utils.IsNotifiedEnabledAndSend(d.notificationFlag, pluginNotificationFlag)
-	if !flagEnabled || flagEnabled && sameFlagExists {
+	subscriptionEnabled, isSubscriptionIncluded := utils.IsSubscribeSpecific(d.subscriptions, notifyInfo.Plugin)
+	if !subscriptionEnabled || subscriptionEnabled && isSubscriptionIncluded {
 		if reqToNotify {
 			err := d.SendNotification(deliverMessage)
 			if err != nil {

--- a/manager/dispatcher/pagerduty.go
+++ b/manager/dispatcher/pagerduty.go
@@ -22,20 +22,18 @@ type pagerdutyMSGEvent struct {
 }
 
 type pagerduty struct {
-	host             string
-	channel          tp.Channel
-	secret           string
-	notificationFlag string
-	pagerEntry       sync.Map
+	host          string
+	channel       tp.Channel
+	secret        string
+	subscriptions []string
+	pagerEntry    sync.Map
 }
 
-func (p *pagerduty) SetDispatcher(firstRunMsg bool, pluginNotificationFlag string, preStat tp.StateFlag, notifyInfo tp.NotifyInfo) error {
-
+func (p *pagerduty) SetDispatcher(firstRunMsg bool, preStat tp.StateFlag, notifyInfo tp.NotifyInfo) error {
 	reqToNotify, _, deliverMessage := messageHandler(firstRunMsg, preStat, notifyInfo)
-	flagEnabled, sameFlagExist := utils.IsNotifiedEnabledAndSend(p.notificationFlag, pluginNotificationFlag)
-	if !flagEnabled || flagEnabled && sameFlagExist {
+	subscriptionEnabled, isSubscriptionIncluded := utils.IsSubscribeSpecific(p.subscriptions, notifyInfo.Plugin)
+	if !subscriptionEnabled || subscriptionEnabled && isSubscriptionIncluded {
 		if reqToNotify {
-
 			err := p.SendNotification(deliverMessage)
 			if err != nil {
 				log.Error().Str("module", "dispatcher").Msgf("Channel(Pagerduty): Send notification error: %s", err)

--- a/manager/dispatcher/slack.go
+++ b/manager/dispatcher/slack.go
@@ -20,7 +20,7 @@ type slack struct {
 	host             string
 	channel          tp.Channel
 	secret           string
-	notificationFlag string
+	subscriptions    []string
 	reminderSchedule []string
 	reminderCron     *cron.Cron
 	entry            sync.Map
@@ -30,11 +30,11 @@ type SlackRequestBody struct {
 	Text string `json:"text"`
 }
 
-func (s *slack) SetDispatcher(firstRunMsg bool, pluginNotificationFlag string, preStat tp.StateFlag, notifyInfo tp.NotifyInfo) error {
+func (s *slack) SetDispatcher(firstRunMsg bool, preStat tp.StateFlag, notifyInfo tp.NotifyInfo) error {
 	reqToNotify, reminderState, deliverMessage := messageHandler(firstRunMsg, preStat, notifyInfo)
 	pUnique := deliverMessage.Options["pUnique"].(string)
-	flagEnabled, sameFlagExists := utils.IsNotifiedEnabledAndSend(s.notificationFlag, pluginNotificationFlag)
-	if !flagEnabled || flagEnabled && sameFlagExists {
+	subscriptionEnabled, isSubscriptionIncluded := utils.IsSubscribeSpecific(s.subscriptions, notifyInfo.Plugin)
+	if !subscriptionEnabled || subscriptionEnabled && isSubscriptionIncluded {
 		if reqToNotify {
 			err := s.SendNotification(deliverMessage)
 			if err != nil {

--- a/manager/dispatcher/telegram.go
+++ b/manager/dispatcher/telegram.go
@@ -22,17 +22,17 @@ type telegram struct {
 	channel          tp.Channel
 	secret           string
 	chatID           string
-	notificationFlag string
+	subscriptions    []string
 	reminderSchedule []string
 	reminderCron     *cron.Cron
 	entry            sync.Map
 }
 
-func (t *telegram) SetDispatcher(firstRunMsg bool, pluginNotificationFlag string, preStat tp.StateFlag, notifyInfo tp.NotifyInfo) error {
+func (t *telegram) SetDispatcher(firstRunMsg bool, preStat tp.StateFlag, notifyInfo tp.NotifyInfo) error {
 	reqToNotify, reminderState, deliverMessage := messageHandler(firstRunMsg, preStat, notifyInfo)
 	pUnique := deliverMessage.Options["pUnique"].(string)
-	flagEnabled, sameFlagExists := utils.IsNotifiedEnabledAndSend(t.notificationFlag, pluginNotificationFlag)
-	if !flagEnabled || flagEnabled && sameFlagExists {
+	subscriptionEnabled, isSubscriptionIncluded := utils.IsSubscribeSpecific(t.subscriptions, notifyInfo.Plugin)
+	if !subscriptionEnabled || subscriptionEnabled && isSubscriptionIncluded {
 		if reqToNotify {
 			err := t.SendNotification(deliverMessage)
 			if err != nil {

--- a/manager/dispatcher/telegram.go
+++ b/manager/dispatcher/telegram.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	tp "github.com/dsrvlabs/vatz/types"
+	"github.com/dsrvlabs/vatz/utils"
 	"io"
 	"net/http"
 	"sync"
@@ -21,24 +22,26 @@ type telegram struct {
 	channel          tp.Channel
 	secret           string
 	chatID           string
+	notificationFlag string
 	reminderSchedule []string
 	reminderCron     *cron.Cron
 	entry            sync.Map
 }
 
-func (t *telegram) SetDispatcher(firstRunMsg bool, preStat tp.StateFlag, notifyInfo tp.NotifyInfo) error {
+func (t *telegram) SetDispatcher(firstRunMsg bool, pluginNotificationFlag string, preStat tp.StateFlag, notifyInfo tp.NotifyInfo) error {
 	reqToNotify, reminderState, deliverMessage := messageHandler(firstRunMsg, preStat, notifyInfo)
 	pUnique := deliverMessage.Options["pUnique"].(string)
+	flagEnabled, sameFlagExists := utils.IsNotifiedEnabledAndSend(t.notificationFlag, pluginNotificationFlag)
+	if !flagEnabled || flagEnabled && sameFlagExists {
+		if reqToNotify {
+			err := t.SendNotification(deliverMessage)
+			if err != nil {
+				log.Error().Str("module", "dispatcher").Msgf("Channel(Telegram): Send notification error: %s", err)
+				return err
+			}
 
-	if reqToNotify {
-		err := t.SendNotification(deliverMessage)
-		if err != nil {
-			log.Error().Str("module", "dispatcher").Msgf("Channel(Telegram): Send notification error: %s", err)
-			return err
 		}
-
 	}
-
 	if reminderState == tp.ON {
 		newEntries := []cron.EntryID{}
 		/*

--- a/manager/executor/executor_test.go
+++ b/manager/executor/executor_test.go
@@ -55,7 +55,9 @@ func TestExecutorSuccess(t *testing.T) {
 			Port:    testPluginPort,
 			ExecutableMethods: []struct {
 				Name string `yaml:"method_name"`
-			}{},
+			}{
+				{testMethodName},
+			},
 		}
 
 		// Mocks.
@@ -176,7 +178,9 @@ func TestExecutorFailure(t *testing.T) {
 			Name: testPluginName,
 			ExecutableMethods: []struct {
 				Name string `yaml:"method_name"`
-			}{},
+			}{
+				{testMethodName},
+			},
 		}
 
 		// Mocks.

--- a/manager/executor/executor_test.go
+++ b/manager/executor/executor_test.go
@@ -55,8 +55,9 @@ func TestExecutorSuccess(t *testing.T) {
 			Port:    testPluginPort,
 			ExecutableMethods: []struct {
 				Name string `yaml:"method_name"`
+				Flag string `yaml:"flag,omitempty"`
 			}{
-				{testMethodName},
+				{testMethodName, "flag1"},
 			},
 		}
 
@@ -178,8 +179,9 @@ func TestExecutorFailure(t *testing.T) {
 			Name: testPluginName,
 			ExecutableMethods: []struct {
 				Name string `yaml:"method_name"`
+				Flag string `yaml:"flag,omitempty"`
 			}{
-				{testMethodName},
+				{testMethodName, "flag2"},
 			},
 		}
 

--- a/manager/executor/executor_test.go
+++ b/manager/executor/executor_test.go
@@ -55,10 +55,7 @@ func TestExecutorSuccess(t *testing.T) {
 			Port:    testPluginPort,
 			ExecutableMethods: []struct {
 				Name string `yaml:"method_name"`
-				Flag string `yaml:"flag,omitempty"`
-			}{
-				{testMethodName, "flag1"},
-			},
+			}{},
 		}
 
 		// Mocks.
@@ -179,10 +176,7 @@ func TestExecutorFailure(t *testing.T) {
 			Name: testPluginName,
 			ExecutableMethods: []struct {
 				Name string `yaml:"method_name"`
-				Flag string `yaml:"flag,omitempty"`
-			}{
-				{testMethodName, "flag2"},
-			},
+			}{},
 		}
 
 		// Mocks.

--- a/manager/executor/general_executor.go
+++ b/manager/executor/general_executor.go
@@ -66,7 +66,7 @@ func (s *executor) Execute(ctx context.Context, gClient pluginpb.PluginClient, p
 		firstExe, preStatus := s.updateState(pUnique, resp)
 
 		for _, dpSingle := range dispatchers {
-			err = dpSingle.SetDispatcher(firstExe, method.Flag, preStatus, tp.NotifyInfo{
+			err = dpSingle.SetDispatcher(firstExe, preStatus, tp.NotifyInfo{
 				Plugin:     plugin.Name,
 				Method:     method.Name,
 				Address:    plugin.Address,

--- a/manager/executor/general_executor.go
+++ b/manager/executor/general_executor.go
@@ -35,6 +35,7 @@ func (s *executor) Execute(ctx context.Context, gClient pluginpb.PluginClient, p
 		}
 
 		//TODO: Please, add new logic to add param into Map.
+
 		methodMap := map[string]interface{}{
 			"execute_method": method.Name,
 		}
@@ -65,7 +66,7 @@ func (s *executor) Execute(ctx context.Context, gClient pluginpb.PluginClient, p
 		firstExe, preStatus := s.updateState(pUnique, resp)
 
 		for _, dpSingle := range dispatchers {
-			err = dpSingle.SetDispatcher(firstExe, preStatus, tp.NotifyInfo{
+			err = dpSingle.SetDispatcher(firstExe, method.Flag, preStatus, tp.NotifyInfo{
 				Plugin:     plugin.Name,
 				Method:     method.Name,
 				Address:    plugin.Address,

--- a/manager/plugin/plugin.go
+++ b/manager/plugin/plugin.go
@@ -38,9 +38,7 @@ type VatzPluginManager interface {
 	Install(repo, name, version string) error
 	Uninstall(name string) error
 	List() ([]VatzPlugin, error)
-
 	SetEnabled(pluginID string, isEnabled bool) error
-
 	Start(name, args string, logfile *os.File) error
 	Stop(name string) error
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -136,3 +136,15 @@ func InitializeChannel() chan os.Signal {
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	return sigs
 }
+
+func IsNotifiedEnabledAndSend(dispatcherNotificationFlag string, pluginNotificationFlag string) (bool, bool) {
+	isNotifiedEnabled := false
+	isSameFlagExists := false
+	if dispatcherNotificationFlag != "" {
+		isNotifiedEnabled = true
+		if dispatcherNotificationFlag == pluginNotificationFlag {
+			isSameFlagExists = true
+		}
+	}
+	return isNotifiedEnabled, isSameFlagExists
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -137,14 +137,17 @@ func InitializeChannel() chan os.Signal {
 	return sigs
 }
 
-func IsNotifiedEnabledAndSend(dispatcherNotificationFlag string, pluginNotificationFlag string) (bool, bool) {
-	isNotifiedEnabled := false
+func IsSubscribeSpecific(subscriptionList []string, PluginName string) (bool, bool) {
+	doesSpecificSubscribe := false
+	if len(subscriptionList) > 0 {
+		doesSpecificSubscribe = true
+	}
 	isSameFlagExists := false
-	if dispatcherNotificationFlag != "" {
-		isNotifiedEnabled = true
-		if dispatcherNotificationFlag == pluginNotificationFlag {
+	for _, v := range subscriptionList {
+		if v == PluginName {
 			isSameFlagExists = true
+			break
 		}
 	}
-	return isNotifiedEnabled, isSameFlagExists
+	return doesSpecificSubscribe, isSameFlagExists
 }


### PR DESCRIPTION
- Select plugin's dispatcher for notification by Flag

### 1. Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Enhancement
- [ ] Bug/fix (non-breaking change which fixes an issue)
- [ ] others (anything other than above)

---

### 2. Summary
> Please include a summary of the changes and which issue is fixed or solved.

**Related:** # (issue)
close #583
 
**Summary**
For watcher that we created via VATZ, We would like to set a notification method per plugins via flags. 

---

### 3. Comments
> Please, leave a comments if there's further action that requires. 
Setting a Flag on Config as below 

<img width="1184" alt="image" src="https://github.com/user-attachments/assets/92b9766d-b52e-4c64-a3a3-5856688d5c82">
<img width="422" alt="image" src="https://github.com/user-attachments/assets/5cbfbea3-b5a3-4a17-9eb5-f292d102bfa4">

<img width="1040" alt="image" src="https://github.com/user-attachments/assets/6b3cd33e-a320-45df-9b8d-a555651c0008">
<img width="1210" alt="image" src="https://github.com/user-attachments/assets/63e09c08-13f8-4fd3-8177-6f736f245a32">

---

# Updated dispatch_channels to use subscriptions behalf of flag as a list with the plugin name, as shown below. No additional configuration is needed on the Plugin side.
> 1) If no subscriptions are set: All messages will be sent to all dispatch_channels.
> 2) If subscriptions are set with a plugin name: Notifications will be sent only when the status changes for the specified plugins on dispatch_channels

```
subscriptions: 
 - "Plugin names"
 - "Plugin names"
 - "Plugin names" 
```


```
    default_reminder_schedule:
      - "*/30 * * * *"
    dispatch_channels:
      - channel: "discord"
        secret: "https://discord.com/api/webhooks/1000167281428533289/7Pf7v7W7f-v4uK4wkPpuWT1nJalAesD0YgSZA2j2EL7YvANEGOPGLNoTto2DHL93jZHW"
        subscriptions:
          - "w1"
          - "w2"
```